### PR TITLE
remove heading from image

### DIFF
--- a/src/typescript/typescript.md
+++ b/src/typescript/typescript.md
@@ -20,7 +20,7 @@ Please ask questions related to TypeScript in the [Angular chat room](https://bi
 If you find bugs in this training or have suggestions, create an [issue](https://github.com/bitovi/academy/issues) or email `contact@bitovi.com`.
 
 
-## <img src="./static/img/typescript/logo.svg" width="50%"/>
+<img src="./static/img/typescript/logo.svg" width="50%"/>
 
 TypeScript is a typed superset of JavaScript that compiles to plain JavaScript.
 


### PR DESCRIPTION
Remove the heading tag from image to prevent blank link being created on the `bit-toc` component.

<img width="239" alt="Screenshot 2019-06-25 at 21 39 41" src="https://user-images.githubusercontent.com/4574152/60132185-ec7ac900-9792-11e9-93fb-29d9237debc1.png">
