### PR TITLE
Fix deep linking scrolling

### DIFF
--- a/static/static.js
+++ b/static/static.js
@@ -33,6 +33,11 @@ window.PACKAGES = packages;
 			var articleScroll = window.history.state && window.history.state.articleScroll;
 			if(articleScroll) {
 				articleContainer.scrollTop = articleScroll;
+			} else if (window.location.hash) {
+				//if there's no state before and the URL has a hash eg. #collecting-data
+				//then let's scroll to #collecting-data element
+				var element = document.querySelector(window.location.hash);
+				articleContainer.scrollTop  = element.offsetTop - 60; // ~60px for the navigation height
 			}
 		}
 		setArticleScroll();


### PR DESCRIPTION
Fixes #177 

### The Problem:
When the user visit a page in the first time `window.history.state` will be `null` because there's no state that had been set before

### The change:
https://github.com/bitovi/academy/blob/01f113d9f49d79f0df37783c323e5478ff17f370/static/static.js#L32
The function is updated to check if there's no `window.history.state` in this case let's look for `window.location.hash` to see if the user wants to go to a particular section in the page and set `articleContainer.scrollTop` to the `offsetTop` of the section element.
