### PR TITLE
Fix the Slack invite links

### DIFF
--- a/src/angular/angular.md
+++ b/src/angular/angular.md
@@ -8,7 +8,7 @@
 
 ## Before You Begin
 
-<p><a href="https://join.slack.com/t/bitovi-community/shared_invite/enQtNTIzMTE5NzYxMjA3LWMwMzE4MjFkMTI5ZmZjNzllYjc2MzcxOWNmOTg3YjI4NjE0MGFkZGNkOTNlZjlkNDBhNTlmYTcwMzJlZDZjY2Y">
+<p><a href="https://www.bitovi.com/community/slack">
 <img src="https://cdn.brandfolder.io/5H442O3W/as/pl546j-7le8zk-5guop3/Slack_RGB.png?width=200"
   style="float:left"/> <span style="margin-top: 10px;display: inline-block;">Click here to join<br/>Bitovi's Slack Community</span></a></p>
 

--- a/src/bit-u.md
+++ b/src/bit-u.md
@@ -321,7 +321,7 @@ a.quote-link:hover{
           <h4>Get help when you need it</h4>
           <p>Our team of expert front-end developers is only a slack message away.</p>
         </div>
-       <a class="button slack-button full-width" href="https://join.slack.com/t/bitovi-community/shared_invite/enQtNTIzMTE5NzYxMjA3LWMwMzE4MjFkMTI5ZmZjNzllYjc2MzcxOWNmOTg3YjI4NjE0MGFkZGNkOTNlZjlkNDBhNTlmYTcwMzJlZDZjY2Y" target="\_blank"><img src="./static/img/slack-logo.svg" height="20">Join our slack community</a>
+       <a class="button slack-button full-width" href="https://www.bitovi.com/community/slack" target="\_blank"><img src="./static/img/slack-logo.svg" height="20">Join our slack community</a>
       </div>
       <div class="academy-card">
         <div class="academy-card--top">
@@ -545,7 +545,7 @@ a.quote-link:hover{
         </div>
         <h4>Need Help?</h4>
         <p>Reach out to our team via Slack. We can help answer any questions you have about our courses.</p>
-        <a class="button full-width" style="color: white" href="https://join.slack.com/t/bitovi-community/shared_invite/enQtNTIzMTE5NzYxMjA3LWMwMzE4MjFkMTI5ZmZjNzllYjc2MzcxOWNmOTg3YjI4NjE0MGFkZGNkOTNlZjlkNDBhNTlmYTcwMzJlZDZjY2Y" target="\_blank">Chat with us on Slack</a>
+        <a class="button full-width" style="color: white" href="https://www.bitovi.com/community/slack" target="\_blank">Chat with us on Slack</a>
       </div>
       <div class="academy-card course" style="background: transparent; border: none;">&nbsp;</div>
     </div>

--- a/src/debugging-javascript/debugging-javascript.md
+++ b/src/debugging-javascript/debugging-javascript.md
@@ -6,7 +6,7 @@
 
 ## Before You Begin
 
-<a href="https://join.slack.com/t/bitovi-community/shared_invite/enQtNTIzMTE5NzYxMjA3LWMwMzE4MjFkMTI5ZmZjNzllYjc2MzcxOWNmOTg3YjI4NjE0MGFkZGNkOTNlZjlkNDBhNTlmYTcwMzJlZDZjY2Y">
+<a href="https://www.bitovi.com/community/slack">
 <img src="https://cdn.brandfolder.io/5H442O3W/as/pl546j-7le8zk-5guop3/Slack_RGB.png?width=200"
   style="float:left"/> <span style="margin-top: 10px;display: inline-block;">Click here to join<br/>Bitovi's Slack Community</span></a>
 

--- a/src/dom/dom.md
+++ b/src/dom/dom.md
@@ -9,7 +9,7 @@ using it to make a basic tabs widget.
 
 ## Before You Begin
 
-<a href="https://join.slack.com/t/bitovi-community/shared_invite/enQtNTIzMTE5NzYxMjA3LWMwMzE4MjFkMTI5ZmZjNzllYjc2MzcxOWNmOTg3YjI4NjE0MGFkZGNkOTNlZjlkNDBhNTlmYTcwMzJlZDZjY2Y">
+<a href="https://www.bitovi.com/community/slack">
 <img src="https://cdn.brandfolder.io/5H442O3W/as/pl546j-7le8zk-5guop3/Slack_RGB.png?width=200"
   style="float:left"/> <span style="margin-top: 10px;display: inline-block;">Click here to join<br/>Bitovi's Slack Community</span></a>
 

--- a/src/javascript/javascript.md
+++ b/src/javascript/javascript.md
@@ -7,7 +7,7 @@
 
 ## Before You Begin
 
-<a href="https://join.slack.com/t/bitovi-community/shared_invite/enQtNTIzMTE5NzYxMjA3LWMwMzE4MjFkMTI5ZmZjNzllYjc2MzcxOWNmOTg3YjI4NjE0MGFkZGNkOTNlZjlkNDBhNTlmYTcwMzJlZDZjY2Y">
+<a href="https://www.bitovi.com/community/slack">
 <img src="https://cdn.brandfolder.io/5H442O3W/as/pl546j-7le8zk-5guop3/Slack_RGB.png?width=200"
   style="float:left"/> <span style="margin-top: 10px;display: inline-block;">Click here to join<br/>Bitovi's Slack Community</span></a>
 

--- a/src/rxjs/rxjs.md
+++ b/src/rxjs/rxjs.md
@@ -7,7 +7,7 @@
 
 ## Before You Begin
 
-<a href="https://join.slack.com/t/bitovi-community/shared_invite/enQtNTIzMTE5NzYxMjA3LWMwMzE4MjFkMTI5ZmZjNzllYjc2MzcxOWNmOTg3YjI4NjE0MGFkZGNkOTNlZjlkNDBhNTlmYTcwMzJlZDZjY2Y">
+<a href="https://www.bitovi.com/community/slack">
 <img src="https://cdn.brandfolder.io/5H442O3W/as/pl546j-7le8zk-5guop3/Slack_RGB.png?width=200"
   style="float:left"/> <span style="margin-top: 10px;display: inline-block;">Click here to join<br/>Bitovi's Slack Community</span></a>
 

--- a/src/typescript/typescript.md
+++ b/src/typescript/typescript.md
@@ -8,7 +8,7 @@ ready to develop projects in TypeScript.
 
 ## Before You Begin
 
-<a href="https://join.slack.com/t/bitovi-community/shared_invite/enQtNTIzMTE5NzYxMjA3LWMwMzE4MjFkMTI5ZmZjNzllYjc2MzcxOWNmOTg3YjI4NjE0MGFkZGNkOTNlZjlkNDBhNTlmYTcwMzJlZDZjY2Y">
+<a href="https://www.bitovi.com/community/slack">
 <img src="https://cdn.brandfolder.io/5H442O3W/as/pl546j-7le8zk-5guop3/Slack_RGB.png?width=200"
   style="float:left"/> <span style="margin-top: 10px;display: inline-block;">Click here to join<br/>Bitovi's Slack Community</span></a>
 

--- a/src/web-components/web-components.md
+++ b/src/web-components/web-components.md
@@ -7,7 +7,7 @@ This course covers the essentials for building [Web Components](https://develope
 
 ## Before You Begin
 
-<a href="https://join.slack.com/t/bitovi-community/shared_invite/enQtNTIzMTE5NzYxMjA3LWMwMzE4MjFkMTI5ZmZjNzllYjc2MzcxOWNmOTg3YjI4NjE0MGFkZGNkOTNlZjlkNDBhNTlmYTcwMzJlZDZjY2Y">
+<a href="https://www.bitovi.com/community/slack">
 <img src="https://cdn.brandfolder.io/5H442O3W/as/pl546j-7le8zk-5guop3/Slack_RGB.png?width=200"
   style="float:left"/> <span style="margin-top: 10px;display: inline-block;">Click here to join<br/>Bitovi's Slack Community</span></a>
 

--- a/templates/content.mustache
+++ b/templates/content.mustache
@@ -40,8 +40,8 @@
         </div>
         <div class="pullout slack">
           <h6>Get help</h6>
-          <p>If you need <a href="https://join.slack.com/t/bitovi-community/shared_invite/enQtNTIzMTE5NzYxMjA3LWMwMzE4MjFkMTI5ZmZjNzllYjc2MzcxOWNmOTg3YjI4NjE0MGFkZGNkOTNlZjlkNDBhNTlmYTcwMzJlZDZjY2Y">help</a> with an exercise, please reach out to us on
-             <a href="https://join.slack.com/t/bitovi-community/shared_invite/enQtNTIzMTE5NzYxMjA3LWMwMzE4MjFkMTI5ZmZjNzllYjc2MzcxOWNmOTg3YjI4NjE0MGFkZGNkOTNlZjlkNDBhNTlmYTcwMzJlZDZjY2Y">Slack</a></p>
+          <p>If you need <a href="https://www.bitovi.com/community/slack">help</a> with an exercise, please reach out to us on
+             <a href="https://www.bitovi.com/community/slack">Slack</a></p>
         </div>
         <div class="pullout bug">
           <p>If you find a bug, please


### PR DESCRIPTION
We should always link to https://www.bitovi.com/community/slack in case the invite link changes.