### PR TITLE
Upgrade bit-docs-html-codepen-link and code buttons styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
       "bit-docs-prettify": "^0.4.1",
       "bit-docs-tag-demo": "^0.5.3",
       "bit-docs-tag-diff": "^0.1.0",
-      "bit-docs-html-codepen-link": "^1.5.0",
+      "bit-docs-html-codepen-link": "^2.0.0",
       "bit-docs-html-highlight-line": "^0.5.4",
       "bit-docs-html-toc": "^1.1.1",
       "@bitovi/calendar-events-component": "^0.0.11"

--- a/static/styles/prism.less
+++ b/static/styles/prism.less
@@ -1,0 +1,62 @@
+.main-content {
+  div.code-toolbar {
+    line-height: 0;
+    > .toolbar {
+      line-height: 0;
+      border-left: 1px solid #dfdfdf;
+      border-bottom: 1px solid #dfdfdf;
+      background: #eeeeee;
+      top: 0px;
+      right: 0;
+      > .toolbar-item {
+        line-height: 0;
+        &:not(:last-child) {
+          border-right: 1px solid #dfdfdf;
+        }
+      }
+    }
+    @media (hover: none) {
+      > .toolbar {
+        opacity: 1;
+      }
+    }
+
+  }
+  div.code-toolbar {
+    .toolbar a, 
+    .toolbar button, 
+    .toolbar span {
+      background: #eee;
+      background: rgba(238, 238, 238, 1);
+      color: #858585;
+      height: 24px;
+      padding: 0 2em;
+      box-shadow: none;
+      border-radius: 0;
+      cursor: pointer;
+      @media(hover: hover) {
+        &:hover {
+          background: rgba(238, 238, 238, .6);
+          color: #4078c0;
+        }
+      }
+    }
+  }
+
+  pre code .collapse.collapsed {
+    border-top-color: transparent;
+    border-bottom-color: #dfdfdf;
+    height: 25px;
+  }
+  .demo {
+    .tab-content {
+      div.code-toolbar {
+        >.toolbar{
+          top: 0px;
+          right: 1px;
+          border-top: 1px solid #dfdfdf;
+        }
+      }
+    }
+  }
+}

--- a/static/styles/styles.less
+++ b/static/styles/styles.less
@@ -17,6 +17,8 @@
 @import "locate://bit-docs-site/styles/variables.less";
 @import "locate://bit-docs-site/styles/mixins.less";
 
+@import "prism.less";
+
 /*
 Mobile:
 ┌─────────────────────────────────┐
@@ -265,9 +267,7 @@ article summary {
   cursor: pointer;
 }
 
-div.code-toolbar>.toolbar {
-  top: -35px !important;
-}
+
 .code-toolbar .toolbar-item a {
   color: #356fd1 !important;
   text-decoration: none !important;


### PR DESCRIPTION
### Before:
<img width="987" alt="Screen Shot 2020-09-21 at 8 48 59 PM" src="https://user-images.githubusercontent.com/109013/93814046-eac8db00-fc4b-11ea-9d39-bcde5cf051db.png">

### After:

<img width="994" alt="Screen Shot 2020-09-21 at 8 48 39 PM" src="https://user-images.githubusercontent.com/109013/93814099-fa482400-fc4b-11ea-89e2-c7b735626b59.png">

Closes #204 
