### PR TITLE
Fix a link in the tour

### DIFF
--- a/src/react/react.md
+++ b/src/react/react.md
@@ -43,4 +43,4 @@ Throughout this guide, we'll be building out a simple Tic-Tac-Toe game, graduall
 
 ## Next Steps
 
-✏️ Head over to the [first lesson](/learn-react/setting-up-environment.html) and get your environment setup.
+✏️ Head over to the [first lesson](/learn-react/setting-up-your-environment.html) and get your environment setup.


### PR DESCRIPTION
We have a 404 for one of our links. We need to route to "setting-up-your-environment" instead of "setting-up-environment".