### PR TITLE
Page Updates: building-our-first-app

### DIFF
--- a/src/angular/2-building-first-app/app.component.spec.ts
+++ b/src/angular/2-building-first-app/app.component.spec.ts
@@ -1,11 +1,11 @@
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 describe('AppComponent', () => {
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [
         RouterTestingModule
       ],
@@ -16,24 +16,24 @@ describe('AppComponent', () => {
         NO_ERRORS_SCHEMA
       ]
     }).compileComponents();
-  }));
+  });
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
+    const app = fixture.componentInstance;
     expect(app).toBeTruthy();
   });
 
   it(`should have as title 'place-my-order'`, () => {
     const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
+    const app = fixture.componentInstance;
     expect(app.title).toEqual('place-my-order');
   });
 
   it('should render title in a h1 tag', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
-    const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('Place My Order App: Coming Soon!');
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('h1')?.textContent).toContain('Place My Order App: Coming Soon!');
   });
 });

--- a/src/angular/2-building-first-app/building-first-app.md
+++ b/src/angular/2-building-first-app/building-first-app.md
@@ -1,13 +1,13 @@
 @page learn-angular/building-our-first-app Generate an App
 @parent learn-angular 2
 
-@description Learn how to generate an Angular 11 application with it's command line interface (CLI).
+@description Learn how to generate an Angular 13 application with it's command line interface (CLI).
 
 @body
 
 ## How to Use This Guide
 
-This guide will walk you through building an application in Angular 11. Each page of the guide is based on building a new feature, and may have multiple "problems" to solve. Each problem will be explained and include requirements and any set-up steps needed. Most problems will also include unit tests to update to verify the solution has been implemented correctly. The ✏️ icon will be used to indicate when commands need to be run or when files need to be updated. If you have any issues or suggestions as you move through this training, we'd love you to submit a <a href="https://github.com/bitovi/academy/issues/new" target="_blank">GitHub issue</a> for it! 💖
+This guide will walk you through building an application in Angular 13. Each page of the guide is based on building a new feature, and may have multiple "problems" to solve. Each problem will be explained and include requirements and any set-up steps needed. Most problems will also include unit tests to update to verify the solution has been implemented correctly. The ✏️ icon will be used to indicate when commands need to be run or when files need to be updated. If you have any issues or suggestions as you move through this training, we'd love you to submit a <a href="https://github.com/bitovi/academy/issues/new" target="_blank">GitHub issue</a> for it! 💖
 
 ## Overview
 
@@ -21,7 +21,7 @@ In this part, we will:
 
 ## Problem
 
-We want to create a new Angular application and update it to say __Place My Order App: Coming Soon!__ in an `<h1>` element.
+We want to create a new Angular application and update it to say **Place My Order App: Coming Soon!** in an `<h1>` element.
 
 <img src="../static/img/angular/2-generate-an-app/after.png"
   style="border: solid 1px black; max-width: 320px;"/>
@@ -42,12 +42,12 @@ If you're looking for a code editor (aka IDE) to improve your Angular developmen
 
 ### Visual Studio Code
 
-<a href="https://code.visualstudio.com/" target="\_blank">VS Code</a> is Microsoft's modern take on an IDE for app development (P.S. TypeScript is a Microsoft Open Source project).  VS Code has built in TypeScript support for syntax highlighting, IntelliSense code completion, and linting.
+<a href="https://code.visualstudio.com/" target="\_blank">VS Code</a> is Microsoft's modern take on an IDE for app development (P.S. TypeScript is a Microsoft Open Source project). VS Code has built in TypeScript support for syntax highlighting, IntelliSense code completion, and linting.
 
 <a href="../static/img/vs-code-screenshot.png" target="\_blank"><img src="../static/img/vs-code-screenshot.png" width="100%" alt="Visual Studio Code screenshot" /></a>
 
 Helpful Plugins:
-- <a href="https://marketplace.visualstudio.com/items?itemName=natewallace.angular2-inline" target="\_blank">Angular Inline</a>
+
 - <a href="https://marketplace.visualstudio.com/items?itemName=Angular.ng-template" target="\_blank">Angular Language Service</a>
 - <a href="https://marketplace.visualstudio.com/items?itemName=johnpapa.Angular2" target="\_blank">Angular Snippets</a>
 
@@ -58,6 +58,7 @@ Atom is another good modern IDE that easily supports and aids in TypeScript deve
 <a href="../static/img/atom-screenshot.png" target="\_blank"><img src="../static/img/atom-screenshot.png" width="100%" alt="Atom screenshot" /></a>
 
 Helpful Plugins:
+
 - <a href="https://atom.io/packages/atom-typescript" target="\_blank">atom-typescript</a>
 - <a href="https://atom.io/packages/emmet" target="\_blank">emmmet</a>
 - <a href="https://atom.io/packages/autocomplete-modules" target="\_blank">autocomplete-modules</a>
@@ -70,6 +71,7 @@ Helpful Plugins:
 <a href="../static/img/webstorm-screenshot.png" target="\_blank"><img src="../static/img/webstorm-screenshot.png" width="100%" alt="Webstorm screenshot" /></a>
 
 Helpful Plugins:
+
 - <a href="https://next.angular.io/guide/language-service" target="\_blank">Angular Language Service</a>
 
 ## Installing the CLI
@@ -81,7 +83,7 @@ We'll start by globally installing the Angular CLI.
 ✏️ Run the following:
 
 ```shell
-npm install -g @angular/cli@11
+npm install -g @angular/cli@13
 ```
 
 ## Generating a new app
@@ -100,76 +102,58 @@ cd place-my-order
 ```
 
 This will create a new Angular Workspace, generate an app module, needed config files, and test suite for your new Angular project. You'll be asked a series of set-up questions:
-1. Would you like to add Angular routing? (__yes__)
-2. Which stylesheet format would you like to use? (__Less__)
+
+1. Would you like to add Angular routing? (**yes**)
+2. Which stylesheet format would you like to use? (**Less**)
 
 Note that we used the prefix property to set our own default prefix. Angular's default is "app", but a good naming convention is to use a short prefix related to your company or application name to easily differentiate from 3rd party utilities.
 
 ```html
-//this looks like it's one of our own app components
+<!-- this looks like it's one of our own app components -->
 <pmo-header></pmo-header>
 
-//safe to assume this a 3rd party
+<!-- safe to assume this a 3rd party -->
 <tabset>
-    <tab heading="Basic title" id="tab1">Basic content</tab>
-    <tab heading="Basic Title 1">Basic content 1</tab>
-    <tab heading="Basic Title 2">Basic content 2</tab>
+  <tab heading="Basic title" id="tab1">Basic content</tab>
+  <tab heading="Basic Title 1">Basic content 1</tab>
+  <tab heading="Basic Title 2">Basic content 2</tab>
 </tabset>
-
 ```
 
-There are several more helpful properties that customize how a project is set up:
-
-### -root
-
-Main directory for all project files. Default empty.
-
-### -sourceRoot
-
-Directory for all project source files.
-
-### -projectType
-
-Can specify application vs. library
-
-### - targets
-
-Used for customizing task commands (build, serve, test) from the default settings.
+There are [several more helpful properties](https://angular.io/cli/new) that customize how a project is set up.
 
 ## Looking at Our Generated Workspace
 
 Let's walk through some of the files that were generated.
 
 ```code
-├── angular.json
-├── package.json
-├── package-lock.json
-├── README.md
-├── tsconfig.json
-├── tslint.json
-├── e2e/
+├── node_modules/
 ├── src/
+|   ├── app/
+|   |   ├── app-routing.module.ts
+|   |   ├── app.component.html
+|   |   ├── app.component.less
+|   |   ├── app.component.spec.ts
+|   |   ├── app.component.ts
+|   |   ├── app.module.ts
+|   ├── assets/
+|   ├── environments/
+|   |   ├── environment.prod.ts
+|   |   ├── environment.ts
 |   ├── index.html
-|   ├── karma.conf.js
 |   ├── main.ts
 |   ├── polyfills.ts
 |   ├── styles.less
 |   ├── test.ts
-|   ├── tsconfig.app.json
-|   ├── tsconfig.spec.json
-|   ├── tslint.json
-|   ├── assets/
-|   ├── environments/
-|   |   ├── environment.ts
-|   |   ├── environment.prod.ts
-|   ├── app/
-|   |   ├── app.module.ts
-|   |   ├── app.component.ts
-|   |   ├── app.component.spec.ts
-|   |   ├── app.component.less
-|   |   ├── app.component.html
-|   |   ├── app-routing.module.ts
-├── node_modules/
+├── .browserslistrc
+├── angular.json
+├── karma.conf.json
+├── package-lock.json
+├── package.json
+├── README.md
+├── tsconfig.app.json
+├── tsconfig.json
+├── tsconfig.spec.json
 ```
 
 ### angular.json
@@ -180,8 +164,7 @@ This file is the config schema for an Angular Workspace. By default Angular conf
 
 ### tsconfig.json
 
-This file contains our TypeScript compiling options. In Angular 11, "strict mode" is set to true by default. Angular's strict mode enforces the [TypeScript strict flag](https://www.staging-typescript.org/tsconfig#strict) and a few additional TypeScript rules: `forceConsistentCasingInFileNames`, `noImplicitReturns`, `noFallthroughCasesInSwitch`. Additionally this mode turns on Angular-specific compiler flags `strictTemplates`, `strictInjectionParameters` and `strictInputAccessModifiers`. This Template type checking was made available with [Angular Ivy](https://angular.io/guide/ivy) and will throw compiler errors for incorrect typings inside templates. 
-
+This file contains our TypeScript compiling options. Starting from Angular 12, "strict mode" is set to true by default. Angular's strict mode enforces the [TypeScript strict flag](https://www.staging-typescript.org/tsconfig#strict) and a few additional TypeScript rules: `forceConsistentCasingInFileNames`, `noImplicitReturns`, `noFallthroughCasesInSwitch`. Additionally this mode turns on Angular-specific compiler flags `strictTemplates`, `strictInjectionParameters` and `strictInputAccessModifiers`. This Template type checking was made available with [Angular Ivy](https://angular.io/guide/ivy) and will throw compiler errors for incorrect typings inside templates.
 
 ```json
 /* To learn more about this file see: https://angular.io/config/tsconfig. */
@@ -192,6 +175,8 @@ This file contains our TypeScript compiling options. In Angular 11, "strict mode
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
@@ -200,26 +185,28 @@ This file contains our TypeScript compiling options. In Angular 11, "strict mode
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "es2015",
+    "target": "es2017",
     "module": "es2020",
     "lib": [
-      "es2018",
+      "es2020",
       "dom"
     ]
   },
   "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true
   }
 }
-```
-@highlight 8
 
+```
+
+@highlight 8
 
 ### src/main.ts
 
-This is the entry point of our application, it compiles and bootstraps our app.  
+This is the entry point of our application, it compiles and bootstraps our app.
 
 ### src/index.html
 
@@ -228,18 +215,17 @@ This should feel familiar - our main index page.
 ```html
 <!doctype html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <title>PlaceMyOrder</title>
-        <base href="/">
-
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="icon" type="image/x-icon" href="favicon.ico">
-    </head>
-    <body>
-        //our entry component
-        <pmo-root></pmo-root>
-    </body>
+<head>
+  <meta charset="utf-8">
+  <title>PlaceMyOrder</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/x-icon" href="favicon.ico">
+</head>
+<body>
+  <!-- our entry component -->
+  <pmo-root></pmo-root>
+</body>
 </html>
 ```
 
@@ -249,14 +235,14 @@ This file is the root module for our app. Every Angular app has at least one mod
 
 - declarations [array]: where we include components, directives, and pipes that will be used by this module.
 - imports [array]: where we include any other modules our app needs to use. This may include 3rd party modules like bootstrap datepickers, or modules we've created.
-- providers [array]: where we include services that we want used at the global app level
+- providers [array]: where we include services that we want used at the module level
 - bootstrap [array]: where we include the root AppModule - this is the main Application view that hosts all of our other app views.
 
 Further reading: <a href="https://angular.io/guide/architecture-services#dependency-injection-di" target="\_blank">Dependency Injection in Angular</a>
 
 ### src/app/app.component.ts
 
-This is our root component, you saw it called in our index.html file as ``<app-root></app-root>``
+This is our root component, you saw it called in our index.html file as `<pmo-root></pmo-root>`
 
 ## Serving An Application
 
@@ -273,7 +259,7 @@ The `start` script command value is `ng serve` which starts a development server
 When we use the CLI to create modules, components, services, etc, it will create spec files
 for us.
 
-✏️ Run tests in a __new__ command line with:
+✏️ Run tests in a **new** command line with:
 
 ```shell
 npm run test
@@ -283,9 +269,9 @@ npm run test
 
 The change we needed to make for our tests to pass is on the highlighted line 37.
 
-We also included `schemas` metadata for our module. <a href="https://angular.io/api/core/NO_ERRORS_SCHEMA">NO_ERRORS_SCHEMA</a> will keep the compiler from throwing errors when unknown components are included in the tested components. In unit tests we often only want to test the very small piece of code we're work on and don't care about deeply nested components <a href="https://medium.com/@fivedicephoto/why-you-shouldnt-use-no-errors-schema-in-angular-unit-tests-cdd478c30782" target="\_blank">unless we're testing the props in a parent/child component relationship</a>. For our purposes in this training, it's safe to use here.  
+We also included `schemas` metadata for our module. <a href="https://angular.io/api/core/NO_ERRORS_SCHEMA">NO_ERRORS_SCHEMA</a> will keep the compiler from throwing errors when unknown components are included in the tested components. In unit tests we often only want to test the very small piece of code we're work on and don't care about deeply nested components <a href="https://medium.com/@fivedicephoto/why-you-shouldnt-use-no-errors-schema-in-angular-unit-tests-cdd478c30782" target="\_blank">unless we're testing the props in a parent/child component relationship</a>. For our purposes in this training, it's safe to use here.
 
-✏️ Update __src/app.component.spec.ts__:
+✏️ Update **src/app.component.spec.ts**:
 
 @sourceref ./app.component.spec.ts
 @highlight 37
@@ -294,12 +280,13 @@ We also included `schemas` metadata for our module. <a href="https://angular.io/
 
 Let's change the markup to look like the home page of our place my order app.
 
-✏️ Update __src/app/app.component.html__ to:
+✏️ Update **src/app/app.component.html** to:
 
 ```html
 <h1>Place My Order App: Coming Soon!</h1>
 <router-outlet></router-outlet>
 ```
+
 @highlight 1-2
 
-When you save your changes, you should see the new h1 tag in your browser at  <a href="http://localhost:4200" target="\_blank">localhost:4200</a>.
+When you save your changes, you should see the new h1 tag in your browser at <a href="http://localhost:4200" target="\_blank">localhost:4200</a>.


### PR DESCRIPTION
- update angular 11 references to 13
- remove angular2-inline plugin because it is not relevant anymore (VSCode provides same features by default)
- update npm install command to angular 13
- use HTML comments in .html files
- link to official documentation in extra options of `ng new` command
- update workspace file tree
- replace "global app level" with "module level"
- update tsconfig.json and index.html files
- correctly reference Angular 12 as version that started strict mode as default