### PR TITLE
Page Updates: update rxjs documentation site links

### DIFF
--- a/src/rxjs/0-basics.md
+++ b/src/rxjs/0-basics.md
@@ -147,7 +147,7 @@ unsubscribed. This helps avoid memory leaks.
 ### Unsubscribing
 
 The `observable.subscribe()` method returns
-a [subscription](https://rxjs-dev.firebaseapp.com/api/index/class/Subscription) which can be used to cancel
+a [subscription](https://rxjs.dev/api/index/class/Subscription) which can be used to cancel
 the subscription like:
 
 ```js

--- a/src/rxjs/1-angular.md
+++ b/src/rxjs/1-angular.md
@@ -16,7 +16,7 @@ Who has time to read?  This video covers the content on this page. Watch fullscr
 In this section, we will:
 
 - Create a CodePen setup with Angular and the HTML of our form.
-- Write values to a [Subject](https://rxjs-dev.firebaseapp.com/guide/subject)
+- Write values to a [Subject](https://rxjs.dev/guide/subject)
   and write out the value of the subject in the template.
 
 ## How to solve this problem
@@ -43,7 +43,7 @@ remainder of this tutorial.
 @highlight 12-59,only
 
 
-Initialize a [BehaviorSubject](https://rxjs-dev.firebaseapp.com/api/index/class/BehaviorSubject) instance on a `class` like the following:
+Initialize a [BehaviorSubject](https://rxjs.dev/api/index/class/BehaviorSubject) instance on a `class` like the following:
 
 ```html
 <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/6.2.1/rxjs.umd.min.js"></script>

--- a/src/rxjs/10-show-paying.md
+++ b/src/rxjs/10-show-paying.md
@@ -48,7 +48,7 @@ This is a tricky problem. A promise has state (if it's pending or resolved). We 
 to convert this state to observables.  The pattern is to map the promises to an observable of
 observables and then _flatten_ that observable with `mergeAll`.
 
-- [from](https://rxjs-dev.firebaseapp.com/api/index/function/from) - converts a
+- [from](https://rxjs.dev/api/index/function/from) - converts a
   `Promise` to an observable.  The following `thousand` observable emits
   `1000` when `promise` resolves:
 
@@ -74,7 +74,7 @@ observables and then _flatten_ that observable with `mergeAll`.
   > HINT: `from` and `map` can be used to convert the payment promises to
   > an observable that emits `{status: "resolved", value}`.
 
-- [concat](https://rxjs-dev.firebaseapp.com/api/index/function/concat) concatenates streams so events are produced in order.
+- [concat](https://rxjs.dev/api/index/function/concat) concatenates streams so events are produced in order.
 
   ```html
   <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/6.2.1/rxjs.umd.js"></script>
@@ -105,7 +105,7 @@ observables and then _flatten_ that observable with `mergeAll`.
   > HINT: `concat` can be used to make an observable emit a `{status: "pending"}`
   > __paymentStatus__ object before emitting the `{status: "resolved", value}` __paymentStatus__ object.
 
-- [startWith](https://rxjs-dev.firebaseapp.com/api/operators/startWith)
+- [startWith](https://rxjs.dev/api/operators/startWith)
   returns an Observable that emits the items you specify as arguments before it begins to emit items emitted by the source Observable.
 
   The following uses `startWith` to add  `"A"` before the `"X"` and `"Y"`
@@ -155,7 +155,7 @@ observables and then _flatten_ that observable with `mergeAll`.
   > HINT: `of` can be used to convert plain __paymentStatus__ objects into an observable
   > that emits the __paymentStatus__ object.
 
-- The static [pipe](https://rxjs-dev.firebaseapp.com/api/index/function/pipe) function can be used
+- The static [pipe](https://rxjs.dev/api/index/function/pipe) function can be used
   to combine operators. The following makes a `squareStartingWith2` operator that ensures
   a `2` will be the first number squared and a `4` the first value emitted:
 
@@ -187,7 +187,7 @@ observables and then _flatten_ that observable with `mergeAll`.
   > - a `startWith` operator that ensures an Observable that emits `{status: "waiting"}`
   >   is emitted first.
 
-- [mergeAll](https://rxjs-dev.firebaseapp.com/api/operators/mergeAll) takes an observable that emits inner observables
+- [mergeAll](https://rxjs.dev/api/operators/mergeAll) takes an observable that emits inner observables
   and emits what the inner observables emits.
 
   In the following example, `observables` emits:

--- a/src/rxjs/11-disable-while-pending.md
+++ b/src/rxjs/11-disable-while-pending.md
@@ -95,7 +95,7 @@ numbers.next(2);
 ```
 @codepen
 
-Read more about this technique on [RxJS's documentation](https://rxjs-dev.firebaseapp.com/guide/subject#multicasted-observables).
+Read more about this technique on [RxJS's documentation](https://rxjs.dev/guide/subject#multicasted-observables).
 
 
 ## Solution

--- a/src/rxjs/2-clean-card-number.md
+++ b/src/rxjs/2-clean-card-number.md
@@ -31,12 +31,12 @@ In this section, we will:
 
 ## What you need to know
 
-- RxJS has [operators](http://reactivex.io/documentation/operators.html)
+- RxJS has [operators](https://rxjs.dev/guide/operators)
   ([an older but better explanation](http://reactivex.io/rxjs/manual/overview.html#operators)) that are used to
   convert one observable to another observable.  In RxJS, you typically create your own operators
-  by using operator generator functions like [map](https://rxjs-dev.firebaseapp.com/api/operators/map).
+  by using operator generator functions like [map](https://rxjs.dev/api/operators/map).
 
-  Those operators are passed to [source.pipe(operator)](https://rxjs-dev.firebaseapp.com/api/index/function/pipe) to convert the source observable to a new observable.
+  Those operators are passed to [source.pipe(operator)](https://rxjs.dev/api/index/function/pipe) to convert the source observable to a new observable.
 
   The following uses `map` to create a `mapToNumber` operator:
 

--- a/src/rxjs/8-disable-pay-button.md
+++ b/src/rxjs/8-disable-pay-button.md
@@ -30,7 +30,7 @@ In this section, we will:
 
 ## What you need to know
 
-- The [combineLatest](https://rxjs-dev.firebaseapp.com/api/index/function/combineLatest) static method combines several values into a single value:
+- The [combineLatest](https://rxjs.dev/api/index/function/combineLatest) static method combines several values into a single value:
 
   ```html
   <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/6.2.1/rxjs.umd.js"></script>

--- a/src/rxjs/9-request-payment.md
+++ b/src/rxjs/9-request-payment.md
@@ -69,8 +69,8 @@ In this section, we will:
 - Call [event.preventDefault()](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) to prevent an submit event from posting
   to a url.
 
-- [withLatestFrom](https://rxjs-dev.firebaseapp.com/api/operators/withLatestFrom) works like
-  [combineLatest](https://rxjs-dev.firebaseapp.com/api/index/function/combineLatest), but it
+- [withLatestFrom](https://rxjs.dev/api/operators/withLatestFrom) works like
+  [combineLatest](https://rxjs.dev/api/index/function/combineLatest), but it
   only publishes when the source observable emits a value. It publishes an array
   with the last source value and sibling values.
 


### PR DESCRIPTION
Update links to the RxJS documentation site to point to the current `rxjs.dev` domain instead of the firebase or reactivex domains.