### PR TITLE
Angular: fix order-service issues

### DIFF
--- a/src/angular/16-order-service/2-order.service.spec.ts
+++ b/src/angular/16-order-service/2-order.service.spec.ts
@@ -26,6 +26,7 @@ describe('OrderService', () => {
         {
           _id: 'adsfsdf',
           name: 'Jennifer',
+          restaurant: 'FoodLand',
           address: '123 main',
           phone: '555-555-5555',
           status: 'new',
@@ -52,7 +53,7 @@ describe('OrderService', () => {
     httpMock.verify();
   });
 
-  it('should make a get request to create an order', () => {
+  it('should make a post request to create an order', () => {
     const mockOrder = {
       _id: 'adsfsdf',
       restaurant: '12345',

--- a/src/angular/16-order-service/order-service.md
+++ b/src/angular/16-order-service/order-service.md
@@ -90,10 +90,14 @@ ng test
 
 ## P2: What You Need to Know
 
-- You will need to look at the test code to determine
-  the method signatures on `OrderService`.
+- The method signatures for the methods you'll be adding to `OrderService`:
+  - `getOrders(): Observable<{data: Order[]}>` should make a `GET` request
+  - `createOrder(orderForm: OrderForm): Observable<Order>` should make a `POST` request
+  - `updateOrder(order: Order, status: string): Observable<Order>` should make a `PUT` request to `/orders/<order-id>`
+  - `deleteOrder(orderId: string): Observable<Order>` should make a `DELETE` request to `/orders/<order-id>`
 - You will need to make sure `HttpClient` is imported and
   added as a property in the `OrderService` constructor.
+- You can pass a request `body` using the second argument of `HttpClient` `post` and `put` methods.
 
 ## P2: Solution
 


### PR DESCRIPTION
Address issues described in NGACAD-54 (https://bitovi.atlassian.net/browse/NGACAD-54?atlOrigin=eyJpIjoiMjk1ZjBhZWE3Y2YzNGRjNjg1YzJiYjIyMjZkZmMyZGQiLCJwIjoiaiJ9)

P2 Setup:

- [x] mockOrders items within should make a get request to get orders  test on line 23 should include a value for restaurant to match the expected type
- [x] Description for test on line 55 (should make a get request to create an order) should be updated to reflect that the method should be a POST request

P2 What You Need To Know:

- [x] List the expected method names for the methods the user is being asked to create. 

- [x] Also include method signature and say what kind of HTTP request is to be made

- [ ] Consider importing ResponseData from RestaurantService instead of adding object shape to getOrders return type (will need to export this from restaurant.service.ts

- [x] Add a note about how you pass a POST body with HttpClient