### PR TITLE
Angular: remove redundant instruction

### DIFF
--- a/src/angular/9-form-value-changes/form-value-changes.md
+++ b/src/angular/9-form-value-changes/form-value-changes.md
@@ -186,9 +186,8 @@ Now that our service is in working order, let's populate our dropdowns with stat
 1. Rewrite the `Data` interface to be a generic to work with State and City types as well
 2. Mark state and city dropdowns as disabled until they are populated with data
 3. Fetch the states list when the component first loads (`ngOnInit`) and populate the dropdown options with the values
-4. When the State FormControl value changes, fetch the list of cities with the selected state as the parameter
-5. If the state value changes, fetch the new list of cities, and reset the list of restaurants to an empty array
-6. When a City is selected, fetch the list of restaurants
+4. When the State FormControl value changes, fetch the list of cities for the newly selected state and reset the list of restaurants to an empty array
+5. When a City is selected, fetch the list of restaurants
 
 > Hint: You'll want to clear the fake data from the state and city value props, and move the call to get restaurants out of the ngOnInit function.
 


### PR DESCRIPTION
Combine two instructions for clarity