### PR TITLE
Prompt Student for their email to continue, use cookie to not prompt again once done

### DIFF
--- a/static/static.js
+++ b/static/static.js
@@ -58,3 +58,63 @@ window.PACKAGES = packages;
 		});
 	}
 })();
+
+(function () {
+	/* Bitovi Academy Soft Lock - Join Mailing List to Continue */
+
+	var academyContactEmailSubmitted = function () {
+		var cname = "academyemailprovided"
+		var cvalue = "true"
+		var exdays = 730
+
+		document.getElementById("email-modal").style.display = "none"
+
+		// set cookie to not prompt again
+		const d = new Date()
+		d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000))
+		let expires = "expires="+ d.toUTCString()
+		document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/"
+	}
+
+	var openModal = function () {
+		console.log("You're deleing the Subscription Modal, aren't you?")
+		console.log("That's okay; Looking for a job? Once you finish the course, head over to https://www.bitovi.com/jobs")
+
+		document.getElementById("email-modal").style.display = "block"
+
+		hbspt.forms.create({
+			region: "na1",
+			portalId: "2171535",
+			formId: "822ba57d-1707-4eb0-9b1b-ef5815f33506",
+			target: "#academy-hubspot-form-embed",
+			onFormSubmitted: academyContactEmailSubmitted
+		})
+	}
+
+	var checkScrollDepth = function () {
+		var main = document.querySelector(".content > .main")
+
+		function amountScrolled () {
+			var mainHeight = Math.max(main.scrollHeight, main.offsetHeight, main.clientHeight)
+			var trackLength = mainHeight - (
+				window.innerHeight || (document.documentElement || document.body).clientHeight
+			)
+			var pageScrolled = Math.floor(main.scrollTop / trackLength * 100)
+
+			if (pageScrolled >= 20) {
+				main.removeEventListener("scroll", amountScrolled)
+				openModal()
+			}
+		}
+
+		main.addEventListener("scroll", amountScrolled)
+	}
+
+	if (document.querySelector && document.querySelector(".sidebar-left > ul > li.expanded > ul > li.current")) {
+		// ^ if we're on an internal page of the current academy lesson
+		if (!(/(^|;)\s*academyemailprovided=true(;|$)/g.test(decodeURIComponent(document.cookie)))) {
+			// ^ if the email-already-entered cookie doesn't exist
+			setTimeout(checkScrollDepth, 1 * 1000) // after 1 min, if/as soon as scrolled 20% of page, open the modal 
+		}
+	}
+})();

--- a/static/static.js
+++ b/static/static.js
@@ -114,7 +114,7 @@ window.PACKAGES = packages;
 		// ^ if we're on an internal page of the current academy lesson
 		if (!(/(^|;)\s*academyemailprovided=true(;|$)/g.test(decodeURIComponent(document.cookie)))) {
 			// ^ if the email-already-entered cookie doesn't exist
-			setTimeout(checkScrollDepth, 1 * 1000) // after 1 min, if/as soon as scrolled 20% of page, open the modal 
+			setTimeout(checkScrollDepth, 30 * 1000) // after 30 sec, if/as soon as scrolled 20% of page, open the modal 
 		}
 	}
 })();

--- a/static/styles/styles.less
+++ b/static/styles/styles.less
@@ -695,3 +695,71 @@ tr:nth-child(even) {
 .line-highlight {
   z-index: 1;
 }
+
+#email-modal,
+.email-modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 10;
+}
+
+.email-modal-backdrop {
+  background: rgba(255, 255, 255, 0.5);
+  backdrop-filter: blur(5px);
+}
+
+.email-modal-content {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: white;
+  width: 750px;
+  max-width: 100%;
+  z-index: 10;
+  padding: 1rem;
+  border: 1px solid #eee;
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 10%), 0 10px 10px -5px rgba(0, 0, 0, 4%);
+  border-radius: 8px;
+}
+
+#email-modal-email {
+  border: 1px solid #eee;
+  border-radius: 4px;
+  padding: 0.5rem;
+  width: 250px;
+  max-width: 60%;
+}
+
+.email-modal-content form {
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#email-modal-button {
+  background-color: #cb3036;
+  border: none;
+  color: #fff;
+  font-size: 14px;
+  line-height: 1.5;
+  padding: 4px 10px;
+  cursor: pointer;
+  font-family: Lato, Arial, sans-serif;
+  font-weight: 700;
+  text-decoration: none;
+  display: inline-block;
+  border-radius: 3px;
+  text-align: center;
+  vertical-align: middle;
+  white-space: nowrap;
+  margin-left: 0.5rem;
+}
+
+#email-modal h2 {
+  margin-top: 0;
+}

--- a/templates/content.mustache
+++ b/templates/content.mustache
@@ -47,7 +47,7 @@
         <div class="pullout bug">
           <p>If you find a bug, please
              <a href="https://github.com/bitovi/academy/issues/new">create an issue</a> or email
-             <a href="mailto:contact@bitovi.com?Subject=Training%20Suggestion" target="_blank">contact@bitovi.com<a/></p>
+             <a href="mailto:contact@bitovi.com?Subject=Training%20Suggestion" target="_blank">contact@bitovi.com</a></p>
         </div>
       </div>
     {{/unless}}

--- a/templates/layout.mustache
+++ b/templates/layout.mustache
@@ -66,5 +66,17 @@
     </script>
 
   </div>
+  <div id="email-modal" style="display: none;">
+    <div aria-hidden="true" class="email-modal-backdrop"></div>
+    <div role="region" class="email-modal-content">
+      <h2>Join the Bitovi Newsletter</h2>
+      <p>
+        To start the course, please provide an email.<br />
+        <i style="font-size: 0.8rem;">By providing your email you agree to receive communications from Bitovi</i>
+      </p>
+      <div id="academy-hubspot-form-embed"></div>
+      <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/embed/v2.js"></script>
+    </div>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
https://bitovi.atlassian.net/browse/SALES-28

This is how I've implemented it, please let me know if you'd like changes:

If user is on an internal page (any page nested after the top level), such as the ones between "Learn React" and "View More Courses"
<img width="258" alt="image" src="https://user-images.githubusercontent.com/92131113/194571709-0ef784f7-7ea0-4dc7-bfc2-e774d5356389.png">

After 30 seconds of being on the page, on scroll of the content, if they've passed 20% of the content height (roughly middle of the 2nd header's block on most pages), prompt for their email:
<img width="1565" alt="image" src="https://user-images.githubusercontent.com/92131113/194573113-7df54afc-3611-49cf-854a-d5d9cd330719.png">

The field, label, email validation, and button are all coming from this embedded hubspot form:
https://app.hubspot.com/forms/2171535/822ba57d-1707-4eb0-9b1b-ef5815f33506/performance
the rest of the modal is built into the repo code in this PR

As soon as the form is successfully submitted, the popover close, hubspot sends an email to this address:
<img width="1112" alt="image" src="https://user-images.githubusercontent.com/92131113/194573840-5da50515-b8a6-45ac-b1ba-e46aba388a59.png">
and they add the contact to this Active list:
https://app.hubspot.com/contacts/2171535/lists/355

Additionally, on valid submit, a cookie is added to the page:
`academyemailprovided=true;`
If this cookie exists and is set to that value, none of the above happens. (a user who provides an email once will not be prompted again unless they clear cookies)

---

also fixed a link in the right sidebar that never closed and messed up the markup on the rest of the page (not much affected, easy to not notice)