### PR TITLE
feat(angular) - renamed all car terms to menu item terms

### DIFF
--- a/src/angular/11-declarative-state/mergeMap.html
+++ b/src/angular/11-declarative-state/mergeMap.html
@@ -3,38 +3,38 @@
     const { of, interval, zip } = rxjs;
     const { map, mergeMap, delay } = rxjs.operators;
 
-    // returns a stream that emits the price of a given car after a 500ms delay. this is how a request might operate
-    function pseudoPriceRequest(carName) {
-        if (carName === 'mustang') {
-            return of(40000).pipe(delay(500))
-        } else if (carName === 'camaro') {
-            return of(38000).pipe(delay(500))
+    // returns a stream that emits the price of a given menu item after a 500ms delay. this is how a request might operate
+    function pseudoPriceRequest(menuItem) {
+        if (menuItem === 'Truffle Noodles') {
+            return of(14.99).pipe(delay(500))
+        } else if (menuItem === 'Charred Octopus') {
+            return of(25.99).pipe(delay(500))
         }
     }
 
     // emits the values every 2 seconds in order
-    const pseudoFormValueStream = zip(of('', 'mustang', 'camaro', ''), interval(2000)).pipe(map(([val, num]) => val));
+    const pseudoFormValueStream = zip(of('', 'Truffle Noodles', 'Charred Octopus', ''), interval(2000)).pipe(map(([val, num]) => val));
 
-    // stream that makes a "request" if provided a car name or returns "No Car Selected"
-    const pseudoPriceStream = pseudoFormValueStream.pipe(mergeMap((selectedCar) => {
-        if (selectedCar) {
-            return pseudoPriceRequest(selectedCar).pipe(map(price => '$' + price));
+    // stream that makes a "request" if provided a menu item name or returns "No Item Selected"
+    const pseudoPriceStream = pseudoFormValueStream.pipe(mergeMap((selectedItem) => {
+        if (selectedItem) {
+            return pseudoPriceRequest(selectedItem).pipe(map(price => '$' + price));
         } else {
-            return of('No Car Selected');
+            return of('No Item Selected');
         }
     }));
 
     pseudoPriceStream.subscribe((price) => {
-        console.log('Price Of Selected Car: ' + price);
+        console.log('Price Of Selected Item: ' + price);
     })
 
     // logs:
     // (... 2 seconds pass)
-    // Price Of Selected Car: No Car Selected
+    // Price Of Selected Item: No Item Selected
     // (... 2.5 seconds pass)
-    // Price Of Selected Car: $40000
+    // Price Of Selected Item: $14.99
     // (... 2 seconds pass)
-    // Price Of Selected Car: $38000
+    // Price Of Selected Item: $25.99
     // (... 2 seconds pass)
-    // Price Of Selected Car: No Car Selected
+    // Price Of Selected Item: No Item Selected
 </script>

--- a/src/angular/11-declarative-state/pairwise.html
+++ b/src/angular/11-declarative-state/pairwise.html
@@ -4,21 +4,21 @@
   const { map, pairwise } = rxjs.operators;
 
   // emits the values every 2 seconds in order
-  const cars$ = zip(
-    of('beetle', 'mustang', 'camaro', 'tesla model s'),
+  const menuItems$ = zip(
+    of('Steamed Mussels', 'Truffle Noodles', 'Charred Octopus', 'Onion fries'),
     interval(2000)
   ).pipe(map(([val, num]) => val));
 
-  cars$.pipe(pairwise()).subscribe(([previous, current]) => {
+  menuItems$.pipe(pairwise()).subscribe(([previous, current]) => {
     console.log('Previous: ' + previous, 'Current: ' + current);
   });
 
   // logs:
-  // (... 2 seconds pass), "beetle" is emitted by cars$
-  // (... 2 seconds pass), "mustang" is emitted by cars$
-  // "Previous: beetle" "Current: mustang"
-  // (... 2 seconds pass), "camaro" is emitted by cars$
-  // "Previous: mustang" "Current: camaro"
-  // (... 2 seconds pass), "tesla model s" is emitted by cars$
-  // "Previous: camaro" "Current: tesla model s"
+  // (... 2 seconds pass), "Steamed Mussels" is emitted by menuItems$
+  // (... 2 seconds pass), "Truffle Noodles" is emitted by menuItems$
+  // "Previous: Steamed Mussels" "Current: Truffle Noodles"
+  // (... 2 seconds pass), "Charred Octopus" is emitted by menuItems$
+  // "Previous: Truffle Noodles" "Current: Charred Octopus"
+  // (... 2 seconds pass), "Onion fries" is emitted by menuItems$
+  // "Previous: Charred Octopus" "Current: Onion fries"
 </script>

--- a/src/angular/11-declarative-state/shareReplay.html
+++ b/src/angular/11-declarative-state/shareReplay.html
@@ -5,7 +5,7 @@
 
   // emits the values every 2 seconds in order
   const pseudoFormValueStream$ = zip(
-    of('mustang', 'camaro', 'corvette'),
+    of('Truffle Noodles', 'Charred Octopus', 'Gunthorp Chicken'),
     interval(2000)
   ).pipe(map(([val, num]) => val));
 
@@ -13,36 +13,36 @@
   const sharedFormValues$ = pseudoFormValueStream$.pipe(shareReplay(1));
 
   // subscriber 1, will subscribe to stream, starting values to be emitted
-  sharedFormValues$.subscribe((carName) => {
-    console.log('s1: ' + carName);
+  sharedFormValues$.subscribe((menuItem) => {
+    console.log('s1: ' + menuItem);
   });
 
-  // subscriber 2, subscribes late, but still emits 'mustang' because the stream replays it.
+  // subscriber 2, subscribes late, but still emits 'Truffle Noodles' because the stream replays it.
   // afterwards works like subscriber 1, logging at the same time since they're both listening to same hot observable.
   setTimeout(() => {
-    sharedFormValues$.subscribe((carName) => {
-      console.log('s2: ' + carName);
+    sharedFormValues$.subscribe((menuItem) => {
+      console.log('s2: ' + menuItem);
     });
   }, 2500);
 
-  // subscriber 3, subscribes after the stream completes, but still emits 'corvette' because the stream replays it.
+  // subscriber 3, subscribes after the stream completes, but still emits 'Gunthorp Chicken' because the stream replays it.
   setTimeout(() => {
-    sharedFormValues$.subscribe((carName) => {
-      console.log('s3: ' + carName);
+    sharedFormValues$.subscribe((menuItem) => {
+      console.log('s3: ' + menuItem);
     });
   }, 6500);
 
   // logs:
   // (... 2 seconds pass)
-  // s1: mustang
+  // s1: Truffle Noodles
   // (... .5 seconds pass)
-  // s2: mustang
+  // s2: Truffle Noodles
   // (... 1.5 seconds pass)
-  // s1: camaro
-  // s2: camaro
+  // s1: Charred Octopus
+  // s2: Charred Octopus
   // (... 2 seconds pass)
-  // s1: corvette
-  // s2: corvette
+  // s1: Gunthorp Chicken
+  // s2: Gunthorp Chicken
   // (... .5 seconds pass)
-  // s3: corvette
+  // s3: Gunthorp Chicken
 </script>


### PR DESCRIPTION
### Jira

https://bitovi.atlassian.net/browse/NGACAD-80

### Description 

Renamed all car terms to menu item terms. Each new menu item term is found directly in the `place-my-order` shop:

<img width="541" alt="Screen Shot 2022-12-27 at 11 24 59 AM" src="https://user-images.githubusercontent.com/9206193/209707311-3e85267d-a9a4-4bb1-86c8-425def5275fc.png">

<img width="539" alt="Screen Shot 2022-12-27 at 11 25 09 AM" src="https://user-images.githubusercontent.com/9206193/209707320-a411b750-0d4e-4b3a-9cc5-b8f7e2fd28b2.png">

Here is the mapping I did:

beetle -> Steamed Mussels (21.99)
mustang (40000) -> Truffle Noodles (14.99)
camaro (38000) -> Charred Octopus (25.99)
corvette -> Gunthorp Chicken (21.99)
tesla model s -> Onion fries (15.99)