### PR TITLE
feat(angular) - removed form-control class since it is not needed

### DIFF
--- a/src/angular/14-building-order-form/child-component/order-2.component.html
+++ b/src/angular/14-building-order-form/child-component/order-2.component.html
@@ -26,7 +26,6 @@
         <input
           name="name"
           type="text"
-          class="form-control"
           formControlName="name"
         />
         <p>Please enter your name.</p>
@@ -36,7 +35,6 @@
         <input
           name="address"
           type="text"
-          class="form-control"
           formControlName="address"
         />
         <p class="help-text">Please enter your address.</p>
@@ -46,7 +44,6 @@
         <input
           name="phone"
           type="text"
-          class="form-control"
           formControlName="phone"
         />
         <p class="help-text">Please enter your phone number.</p>

--- a/src/angular/14-building-order-form/child-component/order-starter.component.html
+++ b/src/angular/14-building-order-form/child-component/order-starter.component.html
@@ -18,17 +18,17 @@
       </tabset>
       <div class="form-group">
         <label class="control-label">Name:</label>
-        <input name="name" type="text" class="form-control" formControlName="name">
+        <input name="name" type="text" formControlName="name">
         <p>Please enter your name.</p>
       </div>
       <div class="form-group">
         <label class="control-label">Address:</label>
-        <input name="address" type="text" class="form-control" formControlName="address">
+        <input name="address" type="text" formControlName="address">
         <p class="help-text">Please enter your address.</p>
       </div>
       <div class="form-group">
         <label class="control-label">Phone:</label>
-        <input name="phone" type="text" class="form-control" formControlName="phone">
+        <input name="phone" type="text" formControlName="phone">
         <p class="help-text">Please enter your phone number.</p>
       </div>
       <div class="submit">

--- a/src/angular/14-building-order-form/child-component/order.component-childcomponent.html
+++ b/src/angular/14-building-order-form/child-component/order.component-childcomponent.html
@@ -20,7 +20,6 @@
         <input
           name="name"
           type="text"
-          class="form-control"
           formControlName="name"
         />
         <p>Please enter your name.</p>
@@ -30,7 +29,6 @@
         <input
           name="address"
           type="text"
-          class="form-control"
           formControlName="address"
         />
         <p class="help-text">Please enter your address.</p>
@@ -40,7 +38,6 @@
         <input
           name="phone"
           type="text"
-          class="form-control"
           formControlName="phone"
         />
         <p class="help-text">Please enter your phone number.</p>

--- a/src/angular/14-building-order-form/child-component/order.component-props.html
+++ b/src/angular/14-building-order-form/child-component/order.component-props.html
@@ -20,7 +20,6 @@
         <input
           name="name"
           type="text"
-          class="form-control"
           formControlName="name"
         />
         <p>Please enter your name.</p>
@@ -30,7 +29,6 @@
         <input
           name="address"
           type="text"
-          class="form-control"
           formControlName="address"
         />
         <p class="help-text">Please enter your address.</p>
@@ -40,7 +38,6 @@
         <input
           name="phone"
           type="text"
-          class="form-control"
           formControlName="phone"
         />
         <p class="help-text">Please enter your phone number.</p>

--- a/src/angular/14-building-order-form/order.component-final.html
+++ b/src/angular/14-building-order-form/order.component-final.html
@@ -26,7 +26,6 @@
         <input
           name="name"
           type="text"
-          class="form-control"
           formControlName="name"
         />
         <p>Please enter your name.</p>
@@ -36,7 +35,6 @@
         <input
           name="address"
           type="text"
-          class="form-control"
           formControlName="address"
         />
         <p class="help-text">Please enter your address.</p>
@@ -46,7 +44,6 @@
         <input
           name="phone"
           type="text"
-          class="form-control"
           formControlName="phone"
         />
         <p class="help-text">Please enter your phone number.</p>

--- a/src/angular/14-building-order-form/order.component-starter.html
+++ b/src/angular/14-building-order-form/order.component-starter.html
@@ -36,7 +36,6 @@
         <input
           name="name"
           type="text"
-          class="form-control"
           formControlName="name"
         />
         <p>Please enter your name.</p>
@@ -46,7 +45,6 @@
         <input
           name="address"
           type="text"
-          class="form-control"
           formControlName="address"
         />
         <p class="help-text">Please enter your address.</p>
@@ -56,7 +54,6 @@
         <input
           name="phone"
           type="text"
-          class="form-control"
           formControlName="phone"
         />
         <p class="help-text">Please enter your phone number.</p>

--- a/src/angular/14-building-order-form/order.component-withtabs.html
+++ b/src/angular/14-building-order-form/order.component-withtabs.html
@@ -36,7 +36,6 @@
         <input
           name="name"
           type="text"
-          class="form-control"
           formControlName="name"
         />
         <p>Please enter your name.</p>
@@ -46,7 +45,6 @@
         <input
           name="address"
           type="text"
-          class="form-control"
           formControlName="address"
         />
         <p class="help-text">Please enter your address.</p>
@@ -56,7 +54,6 @@
         <input
           name="phone"
           type="text"
-          class="form-control"
           formControlName="phone"
         />
         <p class="help-text">Please enter your phone number.</p>

--- a/src/angular/15-directive/15-directive.md
+++ b/src/angular/15-directive/15-directive.md
@@ -19,7 +19,6 @@ In order to fix this, we will create an Attribute Directive that will change the
   name="phone"
   type="text"
   pmoOnlyNumbers
-  class="form-control"
   formControlName="phone"
 />
 ```
@@ -100,7 +99,6 @@ As we have discussed above, Directives are very useful tools in Angular that can
   name="phone"
   type="text"
   pmoOnlyNumbers
-  class="form-control"
   formControlName="phone"
 />
 ```

--- a/src/angular/15-directive/order.component.directive.html
+++ b/src/angular/15-directive/order.component.directive.html
@@ -26,7 +26,6 @@
         <input
           name="name"
           type="text"
-          class="form-control"
           formControlName="name"
         />
         <p>Please enter your name.</p>
@@ -36,7 +35,6 @@
         <input
           name="address"
           type="text"
-          class="form-control"
           formControlName="address"
         />
         <p class="help-text">Please enter your address.</p>
@@ -47,7 +45,6 @@
           name="phone"
           type="text"
           pmoOnlyNumbers
-          class="form-control"
           formControlName="phone"
         />
         <p class="help-text">Please enter your phone number.</p>

--- a/src/angular/16-order-service/order.component.html
+++ b/src/angular/16-order-service/order.component.html
@@ -60,7 +60,6 @@
         <input
           name="name"
           type="text"
-          class="form-control"
           formControlName="name"
         />
         <p>Please enter your name.</p>
@@ -70,7 +69,6 @@
         <input
           name="address"
           type="text"
-          class="form-control"
           formControlName="address"
         />
         <p class="help-text">Please enter your address.</p>
@@ -81,7 +79,6 @@
           name="phone"
           type="text"
           pmoOnlyNumbers
-          class="form-control"
           formControlName="phone"
         />
         <p class="help-text">Please enter your phone number.</p>

--- a/src/angular/18-item-total-pipe/order.component.html
+++ b/src/angular/18-item-total-pipe/order.component.html
@@ -61,7 +61,6 @@
         <input
           name="name"
           type="text"
-          class="form-control"
           formControlName="name"
         />
         <p>Please enter your name.</p>
@@ -71,7 +70,6 @@
         <input
           name="address"
           type="text"
-          class="form-control"
           formControlName="address"
         />
         <p class="help-text">Please enter your address.</p>
@@ -82,7 +80,6 @@
           name="phone"
           type="text"
           pmoOnlyNumbers
-          class="form-control"
           formControlName="phone"
         />
         <p class="help-text">Please enter your phone number.</p>


### PR DESCRIPTION
### Jira

https://bitovi.atlassian.net/browse/NGACAD-79

### Description

Removed "form-control" class from templates since they appear to not be needed for styles:

<img width="816" alt="Screen Shot 2022-12-27 at 11 46 05 AM" src="https://user-images.githubusercontent.com/9206193/209709469-af647272-87ab-4294-b9aa-27d153251d13.png">

>It should be safe to remove this classname since all elements affected are `input` elements with type `text`. Based on the screenshot above, the styles from `form-control` are all overridden by `input[type=text]`

Removing the use of this classname since it can be confusing to developers new to `FormControl` in Angular. The classname doesn't do anything in terms of styling or for Angular's forms.