### PR TITLE
SALES-118 changed tag from anchor to button

### DIFF
--- a/static/styles/styles.less
+++ b/static/styles/styles.less
@@ -735,6 +735,10 @@ tr:nth-child(even) {
 }
 
 #email-modal-close {
+  background-color: transparent;
+  border-width: 0;
+  line-height: 1;
+  cursor: pointer;
   position: absolute;
   top: 0;
   right: 0;

--- a/templates/layout.mustache
+++ b/templates/layout.mustache
@@ -90,7 +90,7 @@
       </p>
       <div id="academy-hubspot-form-embed"></div>
       <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/embed/v2.js"></script>
-      <a id="email-modal-close" href='javascript:void(0)' role="button" title="dismiss"><img src="{{pathToDest}}/static/img/close.svg" height="24" width="24"></a>
+      <button id="email-modal-close" title="dismiss"><img src="{{pathToDest}}/static/img/close.svg" height="24" width="24"></button>
     </div>
   </div>
 </body>


### PR DESCRIPTION
### Description

Currently, anchor tags are updated programmatically to open new tabs. To avoid this behavior, I've updated the close "button" to use a button tag instead of an anchor tag. I've added some styles to remove the button appearance so aesthetically nothing has changed.
<img width="772" alt="Screen Shot 2023-03-21 at 11 38 51 AM" src="https://user-images.githubusercontent.com/9206193/226709851-55dc1925-75f8-47ce-8b40-b398edde8312.png">
