### PR TITLE
Reinstate community calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ npm run dev
 
 This will take a while the first time. The site will be created in the `academy` folder. Use `http-server` or something similar to view site with automatic refreshing on file-save. (In your browser you may need to open the academy folder if running from root.) If you don't use something like `http-server`, you will need to refresh after changes.
 
+If the upcoming calendar events section returns "Sorry, events can't load right now", it may be an issue with the ip address, so try http://localhost:5500/academy/
+
 ### Changing styles or images
 
 Change `academy/static/styles/styles.less` or add images to `academy/img`, then run:
@@ -124,19 +126,19 @@ This is hidden until the summary is opened.
 </details>
 <!-- ``` -->
 
-> note: All solution codes should be hidden inside a collapsed element. 
+> note: All solution codes should be hidden inside a collapsed element.
 
 ### Code blocks
 
 #### Separating code from .md files
 
-Code blocks can be written directly in the markdown files or written in separate files. 
+Code blocks can be written directly in the markdown files or written in separate files.
 
 The use of separate files for code is entirely optional, but allows the use of `@sourceref` to easily reference it and `@diff` to automatically highlight changes between codeblocks.
 
 #### Highlighting & Minimizing
 
-* Including the `only` keyword will minimize non-highlighted code. Using it is always optional and can be left off.
+- Including the `only` keyword will minimize non-highlighted code. Using it is always optional and can be left off.
 
 #### Manual highlighting
 
@@ -145,8 +147,8 @@ The use of separate files for code is entirely optional, but allows the use of `
 @highlight <line numbers>, only
 ```
 
-* `@sourceref` line is interchangable with code blocks.
-* Sections of highlighted lines can be separated with commas. Ex: `@highlight 1-3, 7-24`
+- `@sourceref` line is interchangable with code blocks.
+- Sections of highlighted lines can be separated with commas. Ex: `@highlight 1-3, 7-24`
 
 #### Automatic Highlighting
 
@@ -156,9 +158,9 @@ To automatically highlight differences between code blocks use the following ins
 @diff <initial version of file> <current, displayed file with changes> only
 ```
 
-* Use relative file paths like first example
-* Requires code be in separate files and the use of `@sourceref`
-* Especially useful for highlighting changes in solution codes
+- Use relative file paths like first example
+- Requires code be in separate files and the use of `@sourceref`
+- Especially useful for highlighting changes in solution codes
 
 ### Links
 

--- a/src/bit-u.md
+++ b/src/bit-u.md
@@ -512,10 +512,8 @@ a.quote-link:hover{
     <a class="button" href="https://www.twitch.tv/bitovi/schedule"><img src="./static/img/calendar.svg" height="20"> View our Twitch Schedule</a>
     <p>Or as we host incredible speakers with Q&A at the monthly ChicagoJS Meetups.</p>
     <a class="button" href="https://www.meetup.com/js-chi/events/"><img src="./static/img/calendar.svg" height="20"> ChicagoJS Meetup Schedule</a>
-    <!-- Community calendar temporarily removed until the calendar is consistently updated again. -->
     <p>Join our community calendar for even more upcoming events.</p> 
     <a class="button" href="https://calendar.google.com/calendar/b/1?cid=anVwaXRlcmpzLmNvbV9nMjd2Y2szNm5pZmJucXJna2N0a29hbnFiNEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t"><img src="./static/img/calendar.svg" height="20"> Subscribe to our calendar</a>
-    <!-- when running locally, must use http://localhost:5500/academy/ instead of ip address to see calendar events locally -->
     <h4>Next events from the community Calendar:</h4>
   <calendar-events api-key="AIzaSyBsNpdGbkTsqn1BCSPQrjO9OaMySjK5Sns" calendar-id="jupiterjs.com_g27vck36nifbnqrgkctkoanqb4@group.calendar.google.com" event-count="3" class="courses">
     <template>

--- a/src/bit-u.md
+++ b/src/bit-u.md
@@ -532,8 +532,8 @@ a.quote-link:hover{
                   <span class='event-group'></span>
                 </p>
               </div>
-              <p class='event-body'></p>
-              <a class='event-url button button-grey full-width' >Register for event</a>
+              <p class='event-body' style="word-break: break-word"></p>
+              <a class='event-url button button-grey full-width'>Register for event</a>
           </div>
         </template>
       </calendar-events>

--- a/src/bit-u.md
+++ b/src/bit-u.md
@@ -513,9 +513,11 @@ a.quote-link:hover{
     <p>Or as we host incredible speakers with Q&A at the monthly ChicagoJS Meetups.</p>
     <a class="button" href="https://www.meetup.com/js-chi/events/"><img src="./static/img/calendar.svg" height="20"> ChicagoJS Meetup Schedule</a>
     <!-- Community calendar temporarily removed until the calendar is consistently updated again. -->
-    <!-- <p>Every two weeks, Bitovi hosts a live training. Subscribe to Bitovi's community calendar to be part of the next one!</p> 
-    <a class="button" href="https://calendar.google.com/calendar/b/1?cid=anVwaXRlcmpzLmNvbV9nMjd2Y2szNm5pZmJucXJna2N0a29hbnFiNEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t"><img src="./static/img/calendar.svg" height="20"> Subscribe to our calendar</a> -->
-  <!-- <calendar-events api-key="AIzaSyBsNpdGbkTsqn1BCSPQrjO9OaMySjK5Sns" calendar-id="jupiterjs.com_g27vck36nifbnqrgkctkoanqb4@group.calendar.google.com" event-count="3" class="courses">
+    <p>Join our community calendar for even more upcoming events.</p> 
+    <a class="button" href="https://calendar.google.com/calendar/b/1?cid=anVwaXRlcmpzLmNvbV9nMjd2Y2szNm5pZmJucXJna2N0a29hbnFiNEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t"><img src="./static/img/calendar.svg" height="20"> Subscribe to our calendar</a>
+    <!-- when running locally, must use http://localhost:5500/academy/ instead of ip address to see calendar events locally -->
+    <h4>Next events from the community Calendar:</h4>
+  <calendar-events api-key="AIzaSyBsNpdGbkTsqn1BCSPQrjO9OaMySjK5Sns" calendar-id="jupiterjs.com_g27vck36nifbnqrgkctkoanqb4@group.calendar.google.com" event-count="3" class="courses">
     <template>
           <div class="academy-card course">
               <h4 class='event-title'></h4>
@@ -534,7 +536,7 @@ a.quote-link:hover{
               <a class='event-url button button-grey full-width' >Register for event</a>
           </div>
         </template>
-      </calendar-events> -->
+      </calendar-events>
   </div>
   <div class="academy-section academy-section--grey">
     <h3>Coming soon</h3>


### PR DESCRIPTION
Community calendar is now actively maintained again, so it's being added back with minor copy changes changes.

<img width="757" alt="image" src="https://user-images.githubusercontent.com/65362632/228688498-2d80144a-fbbd-44c1-8110-22a3c2b7812d.png">
