### PR TITLE
Fix deploy with Hubspot API v3

### DIFF
--- a/scripts/hubspot-deploy/academy-page.js
+++ b/scripts/hubspot-deploy/academy-page.js
@@ -17,6 +17,17 @@ class AcademyPage {
     this.$ = cheerio.load(html, {decodeEntities: true});
   }
 
+  // returns all page data at once for easier debugging
+  getPageData() {
+    return {
+      title: this.getTitle(),
+      headHtml: this.getCSSLinks(),
+      bodyHtml: this.getPageContents(),
+      slug: this.slug,
+      metaDescription: this.getMetaDescription()
+    }
+  }
+
   getTitle(){
     return this.$('title').html();
   }

--- a/scripts/hubspot-deploy/hubspot-api.js
+++ b/scripts/hubspot-deploy/hubspot-api.js
@@ -92,7 +92,7 @@ class HubSpotApi {
     }
     try {
       const response =  await this.makeRequest('PATCH', url, data);
-      console.log("Success! Updated page:", response.data.name);
+      console.log("✅ Updated", response.data.slug);
       return response;
     } catch(error) {
       console.error('error during `updatePage` in `hubspot-api.js`');

--- a/scripts/hubspot-deploy/hubspot-api.js
+++ b/scripts/hubspot-deploy/hubspot-api.js
@@ -8,12 +8,14 @@ class HubSpotApi {
   constructor(accessToken, campaignId){
     this.accessToken = accessToken;
     this.campaignId = campaignId;
-    this.baseUrl = 'https://api.hubapi.com/content/api/v2/pages';
+    this.baseUrl = 'https://api.hubapi.com/cms/v3/pages/site-pages';
     this.limiter = new Bottleneck({minTime: 150}),
     this.axios = axios.create({
       baseURL: this.baseUrl,
       headers: {
-        Authorization: `Bearer ${this.accessToken}`,
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        "Authorization": `Bearer ${this.accessToken}`,
       },
     });
   }
@@ -32,30 +34,46 @@ class HubSpotApi {
       }));  
   }
 
-  async getPages(){
-    const url = `?campaign=${this.campaignId}&limit=1000000`;
-    const response = await this.makeRequest('GET', url, {});
+  async getAllPaginatedResults(method, url, results = []) {
+    try {
+      const { data } = await this.makeRequest(method, url, {});
+      results = results.concat(data.results)
+      if (data.paging && data.paging.next) {
+        return this.getAllPaginatedResults(method, data.paging.next.link, results)
+      }
+      return results
+    } catch (error) {
+      throw new Error('There was an error while fetching all paginated results. See `getAllPaginatedResults` in `hubspot-api.js` for more details.')
+    }
+  }
 
-    return response.data.objects.map(page => ({
+  async getPages(){
+    const url = `?campaign=${this.campaignId}&limit=100`;
+    const results = await this.getAllPaginatedResults('GET', url, []);
+
+    const pageData = results.map(page => ({
       campaign: page.campaign,
       id: page.id,
       slug: page.slug
-    })).filter(page => page.campaign === this.campaignId && page.slug.includes('academy'));
+    }))
+    const pages = pageData.filter(page => page.campaign === this.campaignId && page.slug.includes('academy'));
+
+    return pages;
   }
 
   async createPage( {title, headHtml, bodyHtml, slug, metaDescription } ){
     const data = {
       name: title,
-      template_path: 'Custom/Page/Bitovi_July_2016_Theme/Academy.html',
+      templatePath: 'Custom/Page/Bitovi_July_2016_Theme/Academy.html',
       slug: `${slug}`,
-      html_title: title,
-      is_draft: false,
-      publish_immediately: true,
-      footer_html: rawStart+ bodyHtml + rawEnd,
-      head_html: headHtml,
+      htmlTitle: title,
+      currentState: 'PUBLISHED',
+      publishImmediately: true,
+      footerHtml: rawStart+ bodyHtml + rawEnd,
+      headHtml,
       campaign: this.campaignId,
       subcategory: 'site_page',
-      meta_description: metaDescription || ""
+      metaDescription: metaDescription || ""
     };
     const response = await this.makeRequest('POST', '', data)
     return this.publishPage(response.data.id);
@@ -65,17 +83,19 @@ class HubSpotApi {
     const url = `/${pageId}`;
     const data = {
       name: title,
-      html_title: title,
-      footer_html: rawStart+ bodyHtml + rawEnd,
-      head_html: headHtml,
-      meta_description: metaDescription || ""
+      htmlTitle: title,
+      footerHtml: rawStart+ bodyHtml + rawEnd,
+      headHtml,
+      currentState: 'PUBLISHED',
+      metaDescription: metaDescription || "",
+      campaign: this.campaignId
     }
     try {
-      const response =  await this.makeRequest('PUT', url, data);
+      const response =  await this.makeRequest('PATCH', url, data);
       console.log("Success! Updated page:", response.data.name);
       return response;
     } catch(error) {
-      console.error(error);
+      console.error('error during `updatePage` in `hubspot-api.js`');
       throw error;
     }
   }

--- a/scripts/hubspot-deploy/hubspot-publisher.js
+++ b/scripts/hubspot-deploy/hubspot-publisher.js
@@ -1,4 +1,5 @@
 const fs = require('fs').promises;
+const path = require('path');
 const recursive = require("recursive-readdir");
 const HubSpotApi = require("./hubspot-api");
 const AcademyPage = require("./academy-page");
@@ -73,16 +74,25 @@ class HubSpotPublisher {
         page.hubSpotId = localPageOnHubSpot.id;
       }
 
-      this.uploadPage(page)
+      return this.uploadPage(page)
     }));
+
+    console.log(`\n🏁 Uploaded ${pagesForHubSpotUpload.length} pages to HubSpot.\n`);
 
     const pagesToBeDeleted = pagesCurrentlyOnHubSpot.filter(pageCurrentlyOnHubSpot =>
       !pagesForHubSpotUpload.find(pageForHubSpotUpload => pageCurrentlyOnHubSpot.slug === pageForHubSpotUpload.slug)
     );
 
-    // TODO: Remove extra files from the /academy directory
-    console.warn(`Note: There were ${pagesToBeDeleted.length} pages on Bitovi.com that are not in the local project and were left in place.`);
-    pagesToBeDeleted.forEach(page => console.warn(page.slug))
+    if (pagesToBeDeleted.length) {
+      // TODO: uncomment the below line to delete pages
+      // await this.deletePages(pagesToBeDeleted);
+      console.log(`Note: The following ${pagesToBeDeleted.length} pages were removed from Bitovi.com since they did not exist in the local project.`);
+      pagesToBeDeleted.forEach(page => console.log(`  - ${page.slug}`));
+    }
+  }
+
+  async deletePages(pagesToBeDeleted) {
+    await Promise.all(pagesToBeDeleted.map(page => this.hubSpotApi.deletePage(page.id)));
   }
 }
 

--- a/scripts/hubspot-deploy/hubspot-publisher.js
+++ b/scripts/hubspot-deploy/hubspot-publisher.js
@@ -36,24 +36,26 @@ class HubSpotPublisher {
   }
 
   async uploadPage(academyPage) {
+    const { title, headHtml, bodyHtml, slug, metaDescription } = academyPage.getPageData();
+
     if(academyPage.hubSpotId) {
       return this.hubSpotApi.updatePage(
         academyPage.hubSpotId,
         {
-            title: academyPage.getTitle(),
-            headHtml: academyPage.getCSSLinks(),
-            bodyHtml: academyPage.getPageContents(),
-            metaDescription: academyPage.getMetaDescription()
+          title,
+          headHtml,
+          bodyHtml,
+          metaDescription
         }
       );
     }
     else {
       return this.hubSpotApi.createPage({
-          title: academyPage.getTitle(),
-          headHtml: academyPage.getCSSLinks(),
-          bodyHtml: academyPage.getPageContents(),
-          slug: academyPage.slug,
-          metaDescription: academyPage.getMetaDescription()
+        title,
+        headHtml,
+        bodyHtml,
+        metaDescription,
+        slug
       });
     }
   }
@@ -71,7 +73,7 @@ class HubSpotPublisher {
         page.hubSpotId = localPageOnHubSpot.id;
       }
 
-      return this.uploadPage(page)
+      this.uploadPage(page)
     }));
 
     const pagesToBeDeleted = pagesCurrentlyOnHubSpot.filter(pageCurrentlyOnHubSpot =>
@@ -80,6 +82,7 @@ class HubSpotPublisher {
 
     // TODO: Remove extra files from the /academy directory
     console.warn(`Note: There were ${pagesToBeDeleted.length} pages on Bitovi.com that are not in the local project and were left in place.`);
+    pagesToBeDeleted.forEach(page => console.warn(page.slug))
   }
 }
 


### PR DESCRIPTION
Hubspot’s v2 api was not returning all pages when we requested them.  We were not hitting the limit. It appears to be a bug that they fixed in v3 of their API.  The bug was causing some pages to be re-created even though they already existed.  Hubspot was appending an integer for a while then began appending a timestamp to avoid overwriting the existing page.  Looking at the timestamps of the published pages, this has been a problem since December 2020, and 80 copies of each erroring page have been mistakenly published.

I tested the code on the `learn-docker` pages and it successfully updated the files.  Before publishing the entire site, I’m going to let somebody else take a look and run the code.

There was some previous work done to say how many pages need to be deleted.  I updated the code to log the slug of each duplicate/orphaned page, which shows the pages that end in timestamps (Hubspot duplicate prevention).  We will need to make another PR to delete the orphaned pages.

I haven't run the script to fix the other broken files, yet.  We need to do that after review/merge.

Improves debuggability of some code, as well.