### PR TITLE
Clean up the “Multi-parameter Services” section

### DIFF
--- a/exercises/angular/6-restaurant-service/problem/src/app/restaurant/restaurant.component.spec.ts
+++ b/exercises/angular/6-restaurant-service/problem/src/app/restaurant/restaurant.component.spec.ts
@@ -24,7 +24,7 @@ describe('RestaurantService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should make a get request to restaurants', () => {
+  it('should make a GET request to restaurants', () => {
     const mockRestaurants = {
       data: [
         {

--- a/src/angular/10-updating-service-params/restaurant.component-httpparams.ts
+++ b/src/angular/10-updating-service-params/restaurant.component-httpparams.ts
@@ -100,9 +100,9 @@ export class RestaurantComponent implements OnInit, OnDestroy {
 
     this.form.controls.city.valueChanges
       .pipe(takeUntil(this.onDestroy$))
-      .subscribe((value) => {
-        if (value) {
-          this.getRestaurants(state, value);
+      .subscribe(cityName => {
+        if (cityName) {
+          this.getRestaurants(state, cityName);
         }
       });
   }

--- a/src/angular/10-updating-service-params/restaurant.service-httpparams.spec.ts
+++ b/src/angular/10-updating-service-params/restaurant.service-httpparams.spec.ts
@@ -28,7 +28,7 @@ describe('RestaurantService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should make a get request to restaurants', () => {
+  it('should make a GET request to restaurants', () => {
     const mockRestaurants = {
       data: [
         {
@@ -143,7 +143,7 @@ describe('RestaurantService', () => {
     expect(true).toBe(true);
   });
 
-  it('should make a get request to states', () => {
+  it('should make a GET request to states', () => {
     const mockStates = {
       data: [{ name: 'Missouri', short: 'MO' }],
     };
@@ -161,7 +161,7 @@ describe('RestaurantService', () => {
     httpTestingController.verify();
   });
 
-  it('should make a get request to cities', () => {
+  it('should make a GET request to cities', () => {
     const mockCities = {
       data: [{ name: 'Kansas City', state: 'MO' }],
     };

--- a/src/angular/10-updating-service-params/updating-service-params.md
+++ b/src/angular/10-updating-service-params/updating-service-params.md
@@ -1,4 +1,4 @@
-@page learn-angular/updating-service-params Filter Restaurants by City
+@page learn-angular/updating-service-params Multi-parameter Services
 @parent learn-angular 10
 
 @description Learn how to make a service take multiple parameters.
@@ -22,6 +22,10 @@ Now that we are able to capture a user’s state and city preferences, we want t
 <img src="../static/img/angular/10-updating-service-params/after.png"
   style="border: solid 1px black; max-width: 400px;"/>
 
+## What you need to know
+
+- How to use [learn-angular/form-value-changes#how-to-use-httpparams HttpParams] (you learned this in the previous section! ✔️)
+
 ## Technical requirements
 
 In the **src/app/restaurant/restaurant.component.ts** file, update the call to the `getRestaurants` service method to use the city and state values captured from the user’s form input.
@@ -38,13 +42,9 @@ If you’ve implemented the solution correctly, when you use the select boxes to
 
 @diff ../9-form-value-changes/restaurant.service-generics.spec.ts ./restaurant.service-httpparams.spec.ts only
 
-> If you’ve implemented the solution correctly, when you run `npm run test` the tests will pass!
-
-## What you need to know
-
-- How to use [learn-angular/form-value-changes#how-to-use-httpparams HttpParams] (you learned this in the previous section! ✔️)
-
 ## Solution
+
+> If you’ve implemented the solution correctly, when you run `npm run test` the tests will pass!
 
 <details>
 <summary>Click to see the solution</summary>

--- a/src/angular/12-writing-unit-tests/order-state/restaurant.service.spec.ts
+++ b/src/angular/12-writing-unit-tests/order-state/restaurant.service.spec.ts
@@ -26,7 +26,7 @@ describe('RestaurantService', () => {
     expect(restaurantService).toBeTruthy();
   });
 
-  it('should make a get request to states', () => {
+  it('should make a GET request to states', () => {
     const mockStates = {
       data: [{ name: 'Missouri', short: 'MO' }],
     };
@@ -44,7 +44,7 @@ describe('RestaurantService', () => {
     httpTestingController.verify();
   });
 
-  it('should make a get request to cities', () => {
+  it('should make a GET request to cities', () => {
     const mockCities = {
       data: [{ name: 'Kansas City', state: 'MO' }],
     };
@@ -61,7 +61,7 @@ describe('RestaurantService', () => {
     httpTestingController.verify();
   });
 
-  it('should make a get request to restaurant', () => {
+  it('should make a GET request to restaurant', () => {
     const mockRestaurant = {
       name: 'Brunch Place',
       slug: 'brunch-place',

--- a/src/angular/12-writing-unit-tests/restaurant.service.spec-withrestaurant.ts
+++ b/src/angular/12-writing-unit-tests/restaurant.service.spec-withrestaurant.ts
@@ -28,7 +28,7 @@ describe('RestaurantService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should make a get request to restaurants', () => {
+  it('should make a GET request to restaurants', () => {
     const mockRestaurants = {
       data: [
         {
@@ -143,7 +143,7 @@ describe('RestaurantService', () => {
     expect(true).toBe(true);
   });
 
-  it('should make a get request to states', () => {
+  it('should make a GET request to states', () => {
     const mockStates = {
       data: [{ name: 'Missouri', short: 'MO' }],
     };
@@ -161,7 +161,7 @@ describe('RestaurantService', () => {
     httpTestingController.verify();
   });
 
-  it('should make a get request to cities', () => {
+  it('should make a GET request to cities', () => {
     const mockCities = {
       data: [{ name: 'Kansas City', state: 'MO' }],
     };
@@ -178,7 +178,7 @@ describe('RestaurantService', () => {
     httpTestingController.verify();
   });
 
-  it('should make a get request to get a restaurant based on its slug', () => {
+  it('should make a GET request to get a restaurant based on its slug', () => {
     const mockRestaurant = {
       name: 'Brunch Place',
       slug: 'brunch-place',

--- a/src/angular/12-writing-unit-tests/restaurant.service.spec.ts
+++ b/src/angular/12-writing-unit-tests/restaurant.service.spec.ts
@@ -32,7 +32,7 @@ describe('RestaurantService', () => {
     expect(restaurantService).toBeTruthy();
   });
 
-  it('should make a get request to restaurants', () => {
+  it('should make a GET request to restaurants', () => {
     const mockRestaurants = {
       data: [
         {
@@ -146,7 +146,7 @@ describe('RestaurantService', () => {
     expect(true).toBe(true);
   });
 
-  it('should make a get request to states', () => {
+  it('should make a GET request to states', () => {
     const mockStates = {
       data: [{ name: 'Missouri', short: 'MO' }],
     };
@@ -164,7 +164,7 @@ describe('RestaurantService', () => {
     httpTestingController.verify();
   });
 
-  it('should make a get request to cities', () => {
+  it('should make a GET request to cities', () => {
     const mockCities = {
       data: [{ name: 'Kansas City', state: 'MO' }],
     };

--- a/src/angular/12-writing-unit-tests/writing-unit-tests.md
+++ b/src/angular/12-writing-unit-tests/writing-unit-tests.md
@@ -21,7 +21,7 @@ In the next section we’re going to be creating a restaurant detail view. We’
 - How to write a unit test. Here’s a codeblock to get you started:
 
   ```typescript
-  it('should make a get request to get a restaurant based on its slug', () => {
+  it('should make a GET request to get a restaurant based on its slug', () => {
     
   });
   ```

--- a/src/angular/16-order-service/2-order.service.spec.ts
+++ b/src/angular/16-order-service/2-order.service.spec.ts
@@ -20,7 +20,7 @@ describe('OrderService', () => {
     orderService = TestBed.inject(OrderService);
   });
 
-  it('should make a get request to get orders', () => {
+  it('should make a GET request to get orders', () => {
     const mockOrders = {
       data: [
         {

--- a/src/angular/6-restaurant-service/restaurant.service-with-interface.spec.ts
+++ b/src/angular/6-restaurant-service/restaurant.service-with-interface.spec.ts
@@ -23,7 +23,7 @@ describe('RestaurantService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should make a get request to restaurants', () => {
+  it('should make a GET request to restaurants', () => {
     const mockRestaurants = {
       data: [
         {

--- a/src/angular/9-form-value-changes/restaurant.service-citystate.spec.ts
+++ b/src/angular/9-form-value-changes/restaurant.service-citystate.spec.ts
@@ -23,7 +23,7 @@ describe('RestaurantService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should make a get request to restaurants', () => {
+  it('should make a GET request to restaurants', () => {
     const mockRestaurants = {
       data: [
         {
@@ -133,7 +133,7 @@ describe('RestaurantService', () => {
     expect(true).toBe(true);
   });
 
-  it('should make a get request to states', () => {
+  it('should make a GET request to states', () => {
     const mockStates = {
       data: [{ name: 'Missouri', short: 'MO' }],
     };
@@ -151,7 +151,7 @@ describe('RestaurantService', () => {
     httpTestingController.verify();
   });
 
-  it('should make a get request to cities', () => {
+  it('should make a GET request to cities', () => {
     const mockCities = {
       data: [{ name: 'Kansas City', state: 'MO' }],
     };

--- a/src/angular/9-form-value-changes/restaurant.service-generics.spec.ts
+++ b/src/angular/9-form-value-changes/restaurant.service-generics.spec.ts
@@ -28,7 +28,7 @@ describe('RestaurantService', () => {
     expect(service).toBeTruthy();
   });
 
-  it('should make a get request to restaurants', () => {
+  it('should make a GET request to restaurants', () => {
     const mockRestaurants = {
       data: [
         {
@@ -140,7 +140,7 @@ describe('RestaurantService', () => {
     expect(true).toBe(true);
   });
 
-  it('should make a get request to states', () => {
+  it('should make a GET request to states', () => {
     const mockStates = {
       data: [{ name: 'Missouri', short: 'MO' }],
     };
@@ -158,7 +158,7 @@ describe('RestaurantService', () => {
     httpTestingController.verify();
   });
 
-  it('should make a get request to cities', () => {
+  it('should make a GET request to cities', () => {
     const mockCities = {
       data: [{ name: 'Kansas City', state: 'MO' }],
     };


### PR DESCRIPTION
Lots of minor fixes to the text and code, including renaming this page.