### PR TITLE
Move the Requirements to be before the Solution

### DIFF
--- a/src/react-vite/01-intro-to-react/intro-to-react.md
+++ b/src/react-vite/01-intro-to-react/intro-to-react.md
@@ -15,16 +15,16 @@ methods. One of React's notable characteristics has existed from the very
 beginning: the use of [JSX syntax](intro-to-jsx.html) to define the structure of
 a component.
 
-### Key React Concepts
+## Key React Concepts
 
-#### Unidirectional data flow
+### Unidirectional data flow
 
 Data in a React based application flows one way: into a component through
 `props` or state then the user interface is rendered, user interactions cause
 changes to state, changes to state cause props to be updated and passed to the
 component again - restarting the cycle.
 
-#### Virtual DOM
+### Virtual DOM
 
 React's Virtual DOM allows React to quickly determine when the user interface
 needs to be updated; since updates to the browser's DOM are time-consuming only
@@ -35,7 +35,7 @@ to the Virtual DOM. If the results are **the same** no action is taken, if the
 results are **different** the browser's DOM is updated to reflect the new
 Virtual DOM state.
 
-#### Functional components and hooks
+### Functional components and hooks
 
 A major change occurred in 2019 with the introduction of functional components
 and hooks. A component can now be defined using a single function, the component
@@ -43,7 +43,7 @@ can manage its internal data and functionality through the use of
 [hooks](stateful-hooks.html), which are functions that provide data to a
 component or cause the component to render.
 
-#### Server and Client rendering
+### Server and Client rendering
 
 Since version 18 was released, the React team has responded to requests for
 server-side rendering with [React Server
@@ -52,3 +52,7 @@ In this new mode, components default to rendering on the server, improving
 initial browser display performance. Any components that can not render on the
 server or have been explicitly marked as requiring client-side rendering are
 rendered on the client.
+
+## Next steps
+
+TODO

--- a/src/react-vite/02-setting-up-your-environment/setting-up-your-environment.md
+++ b/src/react-vite/02-setting-up-your-environment/setting-up-your-environment.md
@@ -41,15 +41,15 @@ npm install -D @testing-library/jest-dom@6 @testing-library/react@14 jsdom@24 vi
 @sourceref ../../../exercises/react-vite/02-setting-up-your-environment/problem/package.json
 @highlight 10, only
 
-### Requirements
-
-TODO
-
 ### Setup
 
 TODO
 
 ### Verify
+
+TODO
+
+### Exercise
 
 TODO
 

--- a/src/react-vite/03-intro-to-jsx/intro-to-jsx.md
+++ b/src/react-vite/03-intro-to-jsx/intro-to-jsx.md
@@ -26,7 +26,27 @@ TODO
 
 TODO
 
-### Requirements
+### Setup
+
+TODO
+
+```shell
+npm install place-my-order-assets
+```
+
+Remove contents of `src/App.css` file:
+
+@diff ../../../exercises/react-vite/02-setting-up-your-environment/solution/src/App.css ../../../exercises/react-vite/03-intro-to-jsx/01-problem/src/App.css only
+
+@diff ../../../exercises/react-vite/02-setting-up-your-environment/solution/src/index.css ../../../exercises/react-vite/03-intro-to-jsx/01-problem/src/index.css only
+
+### Verify
+
+TODO
+
+@diff ../../../exercises/react-vite/02-setting-up-your-environment/solution/src/App.test.tsx ../../../exercises/react-vite/03-intro-to-jsx/01-problem/src/App.test.tsx only
+
+### Exercise
 
 TODO
 
@@ -52,26 +72,6 @@ Take the below HTML and convert it to JSX:
   </p>
 </div>
 ```
-
-### Setup
-
-TODO
-
-```shell
-npm install place-my-order-assets
-```
-
-Remove contents of `src/App.css` file:
-
-@diff ../../../exercises/react-vite/02-setting-up-your-environment/solution/src/App.css ../../../exercises/react-vite/03-intro-to-jsx/01-problem/src/App.css only
-
-@diff ../../../exercises/react-vite/02-setting-up-your-environment/solution/src/index.css ../../../exercises/react-vite/03-intro-to-jsx/01-problem/src/index.css only
-
-### Verify
-
-TODO
-
-@diff ../../../exercises/react-vite/02-setting-up-your-environment/solution/src/App.test.tsx ../../../exercises/react-vite/03-intro-to-jsx/01-problem/src/App.test.tsx only
 
 ### Solution
 
@@ -100,15 +100,15 @@ TODO
 
 TODO
 
-### Requirements
-
-TODO
-
 ### Setup
 
 TODO
 
 ### Verify
+
+TODO
+
+### Exercise
 
 TODO
 

--- a/src/react-vite/04-components/components.md
+++ b/src/react-vite/04-components/components.md
@@ -26,10 +26,6 @@ TODO
 
 TODO
 
-### Requirements
-
-TODO
-
 ### Setup
 
 TODO
@@ -41,6 +37,10 @@ TODO
 TODO
 
 @sourceref ../../../exercises/react-vite/04-components/01-solution/src/pages/Home/Home.test.tsx
+
+### Exercise
+
+TODO
 
 ### Solution
 
@@ -71,10 +71,6 @@ TODO
 
 TODO
 
-### Requirements
-
-TODO
-
 ### Setup
 
 TODO
@@ -83,6 +79,10 @@ TODO
 @highlight 104, 106, only
 
 ### Verify
+
+TODO
+
+### Exercise
 
 TODO
 

--- a/src/react-vite/05-routing/routing.md
+++ b/src/react-vite/05-routing/routing.md
@@ -26,10 +26,6 @@ TODO
 
 TODO
 
-### Requirements
-
-TODO
-
 ### Setup
 
 TODO
@@ -43,6 +39,10 @@ npm install react-router-dom@6
 @diff ../../../exercises/react-vite/04-components/02-solution/src/main.tsx ../../../exercises/react-vite/05-routing/01-problem/src/main.tsx only
 
 ### Verify
+
+TODO
+
+### Exercise
 
 TODO
 
@@ -75,10 +75,6 @@ TODO
 
 TODO
 
-### Requirements
-
-TODO
-
 ### Setup
 
 TODO
@@ -92,6 +88,10 @@ TODO
 TODO
 
 @diff ../../../exercises/react-vite/05-routing/01-solution/src/App.test.tsx ../../../exercises/react-vite/05-routing/02-problem/src/App.test.tsx only
+
+### Exercise
+
+TODO
 
 ### Solution
 

--- a/src/react-vite/06-props/props.md
+++ b/src/react-vite/06-props/props.md
@@ -26,15 +26,15 @@ TODO
 
 TODO
 
-### Requirements
-
-TODO
-
 ### Setup
 
 TODO
 
 ### Verify
+
+TODO
+
+### Exercise
 
 TODO
 

--- a/src/react-vite/07-styling-in-react/styling-in-react.md
+++ b/src/react-vite/07-styling-in-react/styling-in-react.md
@@ -26,15 +26,15 @@ TODO
 
 TODO
 
-### Requirements
-
-TODO
-
 ### Setup
 
 TODO
 
 ### Verify
+
+TODO
+
+### Exercise
 
 TODO
 

--- a/src/react-vite/08-stateful-hooks/stateful-hooks.md
+++ b/src/react-vite/08-stateful-hooks/stateful-hooks.md
@@ -26,15 +26,15 @@ TODO
 
 TODO
 
-### Requirements
-
-TODO
-
 ### Setup
 
 TODO
 
 ### Verify
+
+TODO
+
+### Exercise
 
 TODO
 

--- a/src/react-vite/09-side-effects/side-effects.md
+++ b/src/react-vite/09-side-effects/side-effects.md
@@ -26,15 +26,15 @@ TODO
 
 TODO
 
-### Requirements
-
-TODO
-
 ### Setup
 
 TODO
 
 ### Verify
+
+TODO
+
+### Exercise
 
 TODO
 

--- a/src/react-vite/10-controlled-vs-uncontrolled/controlled-vs-uncontrolled.md
+++ b/src/react-vite/10-controlled-vs-uncontrolled/controlled-vs-uncontrolled.md
@@ -26,15 +26,15 @@ TODO
 
 TODO
 
-### Requirements
-
-TODO
-
 ### Setup
 
 TODO
 
 ### Verify
+
+TODO
+
+### Exercise
 
 TODO
 

--- a/src/react-vite/11-data-fetching/data-fetching.md
+++ b/src/react-vite/11-data-fetching/data-fetching.md
@@ -26,15 +26,15 @@ TODO
 
 TODO
 
-### Requirements
-
-TODO
-
 ### Setup
 
 TODO
 
 ### Verify
+
+TODO
+
+### Exercise
 
 TODO
 

--- a/src/react-vite/12-testing/testing.md
+++ b/src/react-vite/12-testing/testing.md
@@ -26,15 +26,15 @@ TODO
 
 TODO
 
-### Requirements
-
-TODO
-
 ### Setup
 
 TODO
 
 ### Verify
+
+TODO
+
+### Exercise
 
 TODO
 


### PR DESCRIPTION
After explaining the Overview/Objective/Concepts/Requirements/Setup/Verify/Solution structure to @rlmcneary2 and @rjspencer, we realized that it would make more sense for the “requirements” to be closer to the solution so folks know exactly what they’re trying to accomplish and have a reference while they’re coding a solution.

As part of this, we’re renaming Requirements to Exercise so it also aligns with how we structured the slides.