### PR TITLE
Don’t ignore .env in the React exercises

### DIFF
--- a/exercises/react-vite/.gitignore
+++ b/exercises/react-vite/.gitignore
@@ -1,1 +1,2 @@
 db-data
+!.env

--- a/exercises/react-vite/09-making-http-requests/01-solution/.env
+++ b/exercises/react-vite/09-making-http-requests/01-solution/.env
@@ -1,0 +1,1 @@
+VITE_PMO_API = '//localhost:7070'

--- a/exercises/react-vite/09-making-http-requests/01-solution/.env.development
+++ b/exercises/react-vite/09-making-http-requests/01-solution/.env.development
@@ -1,1 +1,0 @@
-VITE_PMO_API=//localhost:7070


### PR DESCRIPTION
This makes it so `.env` files can be included in the React exercises.