### PR TITLE
Update React Testing Object 1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,26 @@ Everything we know about frontend, backend, UX, and Devops consulting and manage
 
 The following sections detail how to make various improvements to the site. Make sure you have cloned this repo and run:
 
-```
+```sh
 npm install
 ```
+
+### Dev Server
+
+You can start a development server at `http://localhost:8080/academy/` by running:
+
+```sh
+npm run start
+```
+
+`start` incorporates the `npm run dev` command and changes to the source code will cause a rebuild,
+however the browser will **not** reload when the source code changes.
 
 ### Watch mode
 
 When actively working on the content, the most useful option is the watch mode. Run:
 
-```
+```sh
 npm run dev
 ```
 
@@ -22,23 +33,11 @@ This will take a while the first time. The site will be created in the `academy`
 
 If the upcoming calendar events section returns "Sorry, events can’t load right now", it may be an issue with the ip address, so try http://localhost:5500/academy/
 
-### Dev Server
-
-You can start a development server at `http://localhost:8080/` by running:
-
-```sh
-npm run start
-```
-
-`start` incorporates the `npm run dev` command and changes to the source code
-will cause a rebuild, however the browser will **not** reload when the source
-code changes.
-
 ### Changing styles or images
 
 Change `academy/static/styles/styles.less` or add images to `academy/img`, then run:
 
-```
+```sh
 npm run rebuild-assets
 ```
 
@@ -48,7 +47,7 @@ This should take about 5 seconds.
 
 If you want to do a full production build from scratch, run:
 
-```
+```sh
 npm run build
 ```
 
@@ -60,13 +59,13 @@ Academy is automatically deployed when anything is merged into `main`.
 
 Academy can be deployed manually by running the following command:
 
-```
+```sh
 npm run deploy
 ```
 
 Doing so requires access to the Bitovi Hubspot Access token and Campaign Id, which can be found in Bitovi’s 1Password `Academy` vault. Add them to a new `.env` file in this repos root directory:
 
-```
+```sh
 HUBSPOT_TOKEN=<access token>
 HUBSPOT_CAMPAIGN_ID=<campaign id>
 ```
@@ -83,7 +82,7 @@ Create your course in the `src` folder. For best results, follow the organizatio
 
 - The first page in your course should use the following template at the top of the file:
 
-```
+```md
 @page <subdirectory-url> <Page Title>
 @parent bit-academy 4
 
@@ -94,7 +93,7 @@ Create your course in the `src` folder. For best results, follow the organizatio
 
 Once you have a 1200x630 image, you can add a `@metaogimage` tag as follows
 
-```
+```md
 @metaogimage ../static/img/program-management-with-jira/og-thumbnail.png
 ```
 
@@ -104,7 +103,7 @@ Once you have a 1200x630 image, you can add a `@metaogimage` tag as follows
 
 Pages other than the first, introductory page should change the header to this format:
 
-```
+```md
 @page <subdirectory-url>/<specific-page-url> <Page Title>
 @parent <subdirectory-url> <page order number>
 
@@ -162,7 +161,7 @@ The use of separate files for code is entirely optional, but allows the use of `
 
 #### Manual highlighting
 
-```js
+```md
 @sourceref <relative file path for code>
 @highlight <line numbers>, only
 ```
@@ -174,7 +173,7 @@ The use of separate files for code is entirely optional, but allows the use of `
 
 To automatically highlight differences between code blocks use the following instead of above:
 
-```
+```md
 @diff <initial version of file> <current, displayed file with changes> only
 ```
 
@@ -186,7 +185,7 @@ To automatically highlight differences between code blocks use the following ins
 
 Internal and external links can be created with Markdown syntax:
 
-```
+```md
 <!-- Internal link -->
 [Bitovi Academy’s RxJS training](../learn-rxjs.html)
 
@@ -196,7 +195,7 @@ Internal and external links can be created with Markdown syntax:
 
 Internal links can also be created with the following format:
 
-```
+```md
 [learn-typescript/generics TypeScript guide]
 ```
 

--- a/src/react-vite/12-testing/testing.md
+++ b/src/react-vite/12-testing/testing.md
@@ -19,9 +19,9 @@ In this section, we will:
 How do we know when our code is working correctly? How do we know it’s still working correctly in
 the future after we make changes to it?
 
-Unit testing helps by verifying that given certain inputs our code generates expected outputs. So
-far we’ve copied existing tests to prove that we’ve completed the exercise correctly, now let’s dive
-in and learn about how React testing is done.
+Testing helps by verifying that given certain inputs our code generates expected outputs. So far
+we’ve copied existing tests to prove that we’ve completed the exercise correctly, now let’s dive in
+and learn about how React testing is done.
 
 The most basic test is to render a component and validate the DOM that is generated. That’s what
 we’ll do in this first section.
@@ -38,38 +38,13 @@ React Testing Library’s north star is:
 
 > The more your tests resemble the way your software is used, the more confidence they can give you.
 
-This leads to three [Guiding Principles](https://testing-library.com/docs/guiding-principles/):
-
-> 1. If it relates to rendering components, then it should deal with DOM nodes rather than component
->    instances, and it should not encourage dealing with component instances.
-
 React Testing Library encourages tests that focus on how the user interacts with the application,
-rather than the implementation details of the components. This approach makes the tests more
-resilient to changes in the application’s codebase, as they are less likely to break with
-refactoring if the user interface and behavior remain consistent.
-
-> 2. It should be generally useful for testing the application components in the way the user would
->    use it. We are making some trade-offs here because we’re using a computer and often a simulated
->    browser environment, but in general, utilities should encourage tests that use the components
->    the way they're intended to be used.
-
-The library promotes accessibility in React applications by providing tools and encouraging patterns
-that make it easier to create accessible web interfaces. By using semantic HTML and ARIA roles in
-tests, developers are nudged towards building applications that are more accessible to all users,
-including those using assistive technologies.
-
-> 3. Utility implementations and APIs should be simple and flexible.
-
-React Testing Library is designed to be lightweight and straightforward, avoiding the complexity
-that can sometimes come with extensive testing frameworks. It encourages good testing practices,
-such as avoiding testing the internal state of components and instead focusing on what the user
-would see and do. The library’s API is intentionally limited to encourage tests that align with
-these principles.
+rather than the implementation details of the components.
 
 ### <span id="rendering-and-verifying">Rendering and verifying a component in a test</span>
 
-OK, you're convinced that testing-library is a good idea, how do you create tests for your React
-components?
+OK, you're convinced that testing-library is a good idea, how do you use it to create tests for your
+React components?
 
 Let's take a look at an example; say we want to test a component we created named `FormTextField`
 that renders a form field. We expect that the component will generate HTML that looks like this:
@@ -84,16 +59,17 @@ that renders a form field. We expect that the component will generate HTML that 
 We want to test `FormTextField` to make sure it generates the DOM we expect. If you're already
 familiar with testing frontend JavaScript code the following pattern will probably be recognizable:
 each test consists of arguments to the Vite provided test function, `it`. The first argument is a
-short description of what the test is examining. The convention is that the description string takes
-"it" as a prefix and proceeds from there, e.g. "[it] renders correct label and value"
+short description of what the test is verifying. The convention is that the description string takes
+"it" as a prefix and proceeds from there, e.g. "[it] renders the correct label and value"
 
-The second argument to `it` is a callback function that runs the test. In the callback invoke the
-testing-library function `render` and pass it a single argument, JSX for your component including
-props. After `render` completes use `screen` to query the DOM and make assertions about the result.
+The second argument to `it` is a callback function that is called to run the test. Inside the
+callback invoke the testing-library function `render` and pass it a single argument, JSX for your
+component including props. After `render` completes use `screen` to query the DOM and make
+assertions about the result.
 
 ```tsx
-it("renders correct label and value", () => {
-  render(<FormTextField label="Phone" type="tel" value="555-555-5555">);
+it("renders the correct label and value", () => {
+  render(<FormTextField label="Phone" type="tel" value="555-555-5555" />);
   const label = screen.getByText("Phone:");
   expect(label).toBeInTheDocument();
 });
@@ -110,8 +86,8 @@ because the generated DOM is what we expect the user will perceive.
 We also want to validate the `<input>` element, let's update the test:
 
 ```tsx
-it("generates a label from props", () => {
-  render(<FormTextField label="Phone" type="tel" value="555-555-5555">);
+it("renders the correct label and value", () => {
+  render(<FormTextField label="Phone" type="tel" value="555-555-5555" />);
   const label = screen.getByText("Phone:");
   expect(label).toBeInTheDocument();
 
@@ -122,59 +98,17 @@ it("generates a label from props", () => {
 ```
 
 We've used a different query to select the `<input>` element: `getByDisplayValue`. It returns an
-input element whose value matches the provided string. Our test continues to pass because the
-input's value in the DOM matches what we expect.
+input element whose value matches the provided string. React Testing Library has a [suite of "query"
+functions](https://testing-library.com/docs/queries/about) that select elements based on
+characteristics like: role, label text, placeholder text, text, display value, alt text, and title.
+Our test continues to pass because the input's value in the DOM matches what we expect.
 
 Before we move on let's consider the `type` prop — shouldn't we test to be sure it was applied
-properly as the input's `type` attribute? The answer is, maybe. The `tel` value doesn't affect the
+properly as the input's `type` attribute? The answer is, maybe. `type="tel"` doesn't affect the
 appearance of the field in a browser, but it does affect the types of input that can be entered and
 it might affect how the user can enter input. For example a mobile device might display an on-screen
 keyboard that only includes numbers and separators. For now we'll hold off on writing tests that
 check attribute values and see if there is another, more user-focused way, to test this behavior.
-
-<details>
-<summary>Previous text</summary>
-
-Let’s take a look at some code that we added in [Handling User Inputs and
-Forms](./controlled-vs-uncontrolled.html).
-
-@sourceref ../../../exercises/react-vite/11-controlled-vs-uncontrolled/03-problem/src/components/FormTextField/FormTextField.test.tsx
-@highlight 10-15, only
-
-Each test consists of arguments to the Vite provided test function, `it`. The first argument is a
-short description of what the test is examining. The convention is that the description string takes
-"it" as a prefix and proceeds from there, e.g. "(it) renders with correct label and type."
-
-The second argument is a callback function that runs the test. In the example above the first line
-of the callback invokes `render` and passes it a single argument, JSX for the `FormTextField`
-component including props. After `render` completes the `screen` (a test DOM) will contain the
-elements created by our React code.
-
-@sourceref ../../../exercises/react-vite/11-controlled-vs-uncontrolled/03-problem/src/components/FormTextField/FormTextField.test.tsx
-@highlight 11, only
-
-Now it’s time to see if the DOM matches what we expected to create. The React Testing Library
-provides the `screen` object that allows us to select elements from the DOM. In the current scenario
-we’ll use `getByLabelText` which returns the `<input>` associated by `id` with a single `<label>`
-that has the text "Test Label". You may have intuited that `getByLabelText` accepts a string, but it
-also accepts a regex, in this case one that matches any part of the label text and ignores case.
-
-@sourceref ../../../exercises/react-vite/11-controlled-vs-uncontrolled/03-problem/src/components/FormTextField/FormTextField.test.tsx
-@highlight 13, only
-
-Once `screen.getByLabelText` returns, its result can be passed to Vite’s `expect` function to see if
-the result matches what we intended. We use `toBeInTheDocument` (`expect` was augmented with this
-method by importing `@testing-library/jest-dom`) to verify that the element exists in the DOM. This
-satisfies the first part of the test description, "renders with correct label."
-
-If a call to `expect` does not provide the expected result an error will be thrown ending the test.
-
-The second expect will verify the second half of the description, "and type."  `expect` is passed
-the `<input>` element that was rendered and it is examined to see if the value of its `type`
-attribute is set to "text."
-
-Note that this test could also have been written to assign the result of `getByLabelText` to a
-`const` then passed that const to both of the `expect` invocations.
 
 ### Setup 1
 
@@ -226,9 +160,6 @@ Hint: Here’s the JSX you can use for the component:
 <strong>Having issues with your local setup?</strong> See the solution in [StackBlitz](https://stackblitz.com/fork/github/bitovi/academy/tree/main/exercises/react-vite/12-testing/01-solution?file=src/components/FormSelect/FormSelect.test.tsx) or [CodeSandbox](https://codesandbox.io/p/devbox/github/bitovi/academy/tree/main/exercises/react-vite/12-testing/01-solution?file=src/components/FormSelect/FormSelect.test.tsx).
 
 </details>
-
-</details>
-
 
 ## Objective 2: Write a test for handling user interactions
 

--- a/src/react-vite/12-testing/testing.md
+++ b/src/react-vite/12-testing/testing.md
@@ -19,9 +19,9 @@ In this section, we will:
 How do we know when our code is working correctly? How do we know it’s still working correctly in
 the future after we make changes to it?
 
-Unit testing helps by verifying that given certain inputs
-our code generates expected outputs. So far we’ve copied existing tests to prove that we’ve
-completed the exercise correctly, now let’s dive in and learn about how React testing is done.
+Unit testing helps by verifying that given certain inputs our code generates expected outputs. So
+far we’ve copied existing tests to prove that we’ve completed the exercise correctly, now let’s dive
+in and learn about how React testing is done.
 
 The most basic test is to render a component and validate the DOM that is generated. That’s what
 we’ll do in this first section.
@@ -40,14 +40,18 @@ React Testing Library’s north star is:
 
 This leads to three [Guiding Principles](https://testing-library.com/docs/guiding-principles/):
 
-> 1. If it relates to rendering components, then it should deal with DOM nodes rather than component instances, and it should not encourage dealing with component instances.
+> 1. If it relates to rendering components, then it should deal with DOM nodes rather than component
+>    instances, and it should not encourage dealing with component instances.
 
 React Testing Library encourages tests that focus on how the user interacts with the application,
 rather than the implementation details of the components. This approach makes the tests more
 resilient to changes in the application’s codebase, as they are less likely to break with
 refactoring if the user interface and behavior remain consistent.
 
-> 2. It should be generally useful for testing the application components in the way the user would use it. We are making some trade-offs here because we’re using a computer and often a simulated browser environment, but in general, utilities should encourage tests that use the components the way they're intended to be used.
+> 2. It should be generally useful for testing the application components in the way the user would
+>    use it. We are making some trade-offs here because we’re using a computer and often a simulated
+>    browser environment, but in general, utilities should encourage tests that use the components
+>    the way they're intended to be used.
 
 The library promotes accessibility in React applications by providing tools and encouraging patterns
 that make it easier to create accessible web interfaces. By using semantic HTML and ARIA roles in
@@ -56,12 +60,80 @@ including those using assistive technologies.
 
 > 3. Utility implementations and APIs should be simple and flexible.
 
-React Testing Library is designed to be lightweight and straightforward, avoiding the complexity that
-can sometimes come with extensive testing frameworks. It encourages good testing practices, such as
-avoiding testing the internal state of components and instead focusing on what the user would see
-and do. The library’s API is intentionally limited to encourage tests that align with these principles.
+React Testing Library is designed to be lightweight and straightforward, avoiding the complexity
+that can sometimes come with extensive testing frameworks. It encourages good testing practices,
+such as avoiding testing the internal state of components and instead focusing on what the user
+would see and do. The library’s API is intentionally limited to encourage tests that align with
+these principles.
 
-### Rendering and verifying a component in a test
+### <span id="rendering-and-verifying">Rendering and verifying a component in a test</span>
+
+OK, you're convinced that testing-library is a good idea, how do you create tests for your React
+components?
+
+Let's take a look at an example; say we want to test a component we created named `FormTextField`
+that renders a form field. We expect that the component will generate HTML that looks like this:
+
+```html
+<div>
+  <label htmlFor="inputId">Phone:</label>
+  <input id="inputId" type="tel" value="555-555-5555" />
+</div>
+```
+
+We want to test `FormTextField` to make sure it generates the DOM we expect. If you're already
+familiar with testing frontend JavaScript code the following pattern will probably be recognizable:
+each test consists of arguments to the Vite provided test function, `it`. The first argument is a
+short description of what the test is examining. The convention is that the description string takes
+"it" as a prefix and proceeds from there, e.g. "[it] renders correct label and value"
+
+The second argument to `it` is a callback function that runs the test. In the callback invoke the
+testing-library function `render` and pass it a single argument, JSX for your component including
+props. After `render` completes use `screen` to query the DOM and make assertions about the result.
+
+```tsx
+it("renders correct label and value", () => {
+  render(<FormTextField label="Phone" type="tel" value="555-555-5555">);
+  const label = screen.getByText("Phone:");
+  expect(label).toBeInTheDocument();
+});
+```
+
+In the test above we validate that the label is correct. We use the `getByText` function to select a
+single element whose `textContent` matches the string, "Phone:". If you look closely you can see
+that the `<label>` content in the HTML has a ":" (colon) at the end, but the `label` prop does not,
+we can conclude that FormTextField appends the colon — but **the purpose of the test isn't how
+FormTextField works, it's the DOM output that it returns**. After we get an element we then use
+`expect` and `toBeInTheDocument` to verify the element was rendered properly. Our test passes
+because the generated DOM is what we expect the user will perceive.
+
+We also want to validate the `<input>` element, let's update the test:
+
+```tsx
+it("generates a label from props", () => {
+  render(<FormTextField label="Phone" type="tel" value="555-555-5555">);
+  const label = screen.getByText("Phone:");
+  expect(label).toBeInTheDocument();
+
+  // Validate the input value.
+  const input = screen.getByDisplayValue("555-555-5555");
+  expect(input).toBeInTheDocument();
+});
+```
+
+We've used a different query to select the `<input>` element: `getByDisplayValue`. It returns an
+input element whose value matches the provided string. Our test continues to pass because the
+input's value in the DOM matches what we expect.
+
+Before we move on let's consider the `type` prop — shouldn't we test to be sure it was applied
+properly as the input's `type` attribute? The answer is, maybe. The `tel` value doesn't affect the
+appearance of the field in a browser, but it does affect the types of input that can be entered and
+it might affect how the user can enter input. For example a mobile device might display an on-screen
+keyboard that only includes numbers and separators. For now we'll hold off on writing tests that
+check attribute values and see if there is another, more user-focused way, to test this behavior.
+
+<details>
+<summary>Previous text</summary>
 
 Let’s take a look at some code that we added in [Handling User Inputs and
 Forms](./controlled-vs-uncontrolled.html).
@@ -154,6 +226,9 @@ Hint: Here’s the JSX you can use for the component:
 <strong>Having issues with your local setup?</strong> See the solution in [StackBlitz](https://stackblitz.com/fork/github/bitovi/academy/tree/main/exercises/react-vite/12-testing/01-solution?file=src/components/FormSelect/FormSelect.test.tsx) or [CodeSandbox](https://codesandbox.io/p/devbox/github/bitovi/academy/tree/main/exercises/react-vite/12-testing/01-solution?file=src/components/FormSelect/FormSelect.test.tsx).
 
 </details>
+
+</details>
+
 
 ## Objective 2: Write a test for handling user interactions
 


### PR DESCRIPTION
I made minor attempts to make this more "portable." The example code used to illustrate the objective is embedded in the page, rather than referring to "real" code from PMO. I did not change the exercise code - waiting to see if people think that's necessary.

While simpler exercise code with less PMO code around it seems like a good idea, it might also be a "jarring" change from previous the context of previous examples that always built on PMO.