### PR TITLE
angular training improvements

### DIFF
--- a/exercises/angular/6-restaurant-service/problem/src/app/app.component.spec.ts
+++ b/exercises/angular/6-restaurant-service/problem/src/app/app.component.spec.ts
@@ -87,6 +87,7 @@ describe('AppComponent', () => {
     router.navigate(['']);
     fixture.detectChanges();
     tick();
+    fixture.detectChanges();
 
     const homeLinkLi = compiled.querySelector('li');
     expect(homeLinkLi?.classList).toContain('active');

--- a/src/angular/10-updating-service-params/restaurant.component-httpparams.spec.ts
+++ b/src/angular/10-updating-service-params/restaurant.component-httpparams.spec.ts
@@ -362,7 +362,7 @@ describe('RestaurantComponent', () => {
     const stateOption = compiled.querySelector(
       'select[formcontrolname="state"] option:nth-child(2)'
     ) as HTMLInputElement;
-    expect(stateOption.textContent).toEqual(' Missouri ');
+    expect(stateOption.textContent?.trim()).toEqual('Missouri');
     expect(stateOption.value).toEqual('MO');
   }));
 
@@ -390,7 +390,7 @@ describe('RestaurantComponent', () => {
     const cityOption = compiled.querySelector(
       'select[formcontrolname="city"] option:nth-child(2)'
     ) as HTMLInputElement;
-    expect(cityOption.textContent).toEqual(' Sacramento ');
+    expect(cityOption.textContent?.trim()).toEqual('Sacramento');
     expect(cityOption.value).toEqual('Sacramento');
   }));
 
@@ -417,7 +417,7 @@ describe('RestaurantComponent', () => {
     expect(cityFormControl2?.enabled).toBe(true);
   }));
 
-  it('should reset list of cities when new state is selected', fakeAsync((): void => {
+  it('should reset list of restaurants when new state is selected', fakeAsync((): void => {
     fixture.detectChanges(); // detecting changes for createForm func to be called
     fixture.componentInstance.form.get('state')?.patchValue('CA');
     fixture.componentInstance.form.get('city')?.patchValue('Sacramento');

--- a/src/angular/11-declarative-state/restaurant.component.spec.ts
+++ b/src/angular/11-declarative-state/restaurant.component.spec.ts
@@ -380,7 +380,7 @@ describe('RestaurantComponent', () => {
     const stateOption = compiled.querySelector(
       'select[formcontrolname="state"] option:nth-child(2)'
     ) as HTMLInputElement;
-    expect(stateOption.textContent).toEqual(' Missouri ');
+    expect(stateOption.textContent?.trim()).toEqual('Missouri');
     expect(stateOption.value).toEqual('MO');
   }));
 
@@ -414,7 +414,7 @@ describe('RestaurantComponent', () => {
     const cityOption = compiled.querySelector(
       'select[formcontrolname="city"] option:nth-child(2)'
     ) as HTMLInputElement;
-    expect(cityOption.textContent).toEqual(' Sacramento ');
+    expect(cityOption.textContent?.trim()).toEqual('Sacramento');
     expect(cityOption.value).toEqual('Sacramento');
   }));
 
@@ -437,7 +437,7 @@ describe('RestaurantComponent', () => {
     expect(cityFormControl2?.enabled).toBe(true);
   }));
 
-  it('should reset list of cities when new state is selected', fakeAsync((): void => {
+  it('should reset list of restaurants when new state is selected', fakeAsync((): void => {
     fixture.detectChanges(); // detecting changes for createForm func to be called
 
     let restaurantOutput!: Data<Restaurant>;

--- a/src/angular/13-nested-routes/app.component.spec.ts
+++ b/src/angular/13-nested-routes/app.component.spec.ts
@@ -286,6 +286,7 @@ describe('AppComponent', () => {
     router.navigate(['']);
     fixture.detectChanges();
     tick();
+    fixture.detectChanges();
 
     const homeLinkLi = compiled.querySelector('li');
     expect(homeLinkLi?.classList).toContain('active');

--- a/src/angular/14-building-order-form/app.component.spec.ts
+++ b/src/angular/14-building-order-form/app.component.spec.ts
@@ -297,6 +297,7 @@ describe('AppComponent', () => {
     router.navigate(['']);
     fixture.detectChanges();
     tick();
+    fixture.detectChanges();
 
     const homeLinkLi = compiled.querySelector('li');
     expect(homeLinkLi?.classList).toContain('active');

--- a/src/angular/17-order-history-component/app.component.spec.ts
+++ b/src/angular/17-order-history-component/app.component.spec.ts
@@ -308,6 +308,7 @@ describe('AppComponent', () => {
     router.navigate(['']);
     fixture.detectChanges();
     tick();
+    fixture.detectChanges();
 
     const homeLinkLi = compiled.querySelector('li');
     expect(homeLinkLi?.classList).toContain('active');

--- a/src/angular/18-item-total-pipe/app.component.spec.ts
+++ b/src/angular/18-item-total-pipe/app.component.spec.ts
@@ -311,6 +311,7 @@ describe('AppComponent', () => {
     router.navigate(['']);
     fixture.detectChanges();
     tick();
+    fixture.detectChanges();
 
     const homeLinkLi = compiled.querySelector('li');
     expect(homeLinkLi?.classList).toContain('active');

--- a/src/angular/5-creating-navigation/app.component.spec.ts
+++ b/src/angular/5-creating-navigation/app.component.spec.ts
@@ -87,6 +87,7 @@ describe('AppComponent', () => {
     router.navigate(['']);
     fixture.detectChanges();
     tick();
+    fixture.detectChanges();
 
     const homeLinkLi = compiled.querySelector('li');
     expect(homeLinkLi?.classList).toContain('active');

--- a/src/angular/7-pull-restaurant-data-into-view/app.component.spec.ts
+++ b/src/angular/7-pull-restaurant-data-into-view/app.component.spec.ts
@@ -270,6 +270,7 @@ describe('AppComponent', () => {
     router.navigate(['']);
     fixture.detectChanges();
     tick();
+    fixture.detectChanges();
 
     const homeLinkLi = compiled.querySelector('li');
     expect(homeLinkLi?.classList).toContain('active');

--- a/src/angular/8-state-city-options/app.component.spec.ts
+++ b/src/angular/8-state-city-options/app.component.spec.ts
@@ -275,6 +275,7 @@ describe('AppComponent', () => {
     router.navigate(['']);
     fixture.detectChanges();
     tick();
+    fixture.detectChanges();
 
     const homeLinkLi = compiled.querySelector('li');
     expect(homeLinkLi?.classList).toContain('active');

--- a/src/angular/9-form-value-changes/restaurant.component-citystate.spec.ts
+++ b/src/angular/9-form-value-changes/restaurant.component-citystate.spec.ts
@@ -360,7 +360,7 @@ describe('RestaurantComponent', () => {
     const stateOption = compiled.querySelector(
       'select[formcontrolname="state"] option:nth-child(2)'
     ) as HTMLInputElement;
-    expect(stateOption.textContent).toEqual(' Missouri ');
+    expect(stateOption.textContent?.trim()).toEqual('Missouri');
     expect(stateOption.value).toEqual('MO');
   }));
 
@@ -388,7 +388,7 @@ describe('RestaurantComponent', () => {
     const cityOption = compiled.querySelector(
       'select[formcontrolname="city"] option:nth-child(2)'
     ) as HTMLInputElement;
-    expect(cityOption.textContent).toEqual(' Sacramento ');
+    expect(cityOption.textContent?.trim()).toEqual('Sacramento');
     expect(cityOption.value).toEqual('Sacramento');
   }));
 
@@ -415,7 +415,7 @@ describe('RestaurantComponent', () => {
     expect(cityFormControl2?.enabled).toBe(true);
   }));
 
-  it('should reset list of cities when new state is selected', fakeAsync((): void => {
+  it('should reset list of restaurants when new state is selected', fakeAsync((): void => {
     fixture.detectChanges(); // detecting changes for createForm func to be called
     fixture.componentInstance.form.get('state')?.patchValue('CA');
     fixture.componentInstance.form.get('city')?.patchValue('Sacramento');


### PR DESCRIPTION
- make tests more forgiving by allowing different template formatting
- allow a different solution to `should make the home navigation link class active when the router navigates to "/" path` test that requires additional detectChanges
- update test description to be a list of restaurants instead of the wrong list of cities