### PR TITLE
Hide the “Configuration” page

### DIFF
--- a/src/typescript/04-configuration/configuration.md
+++ b/src/typescript/04-configuration/configuration.md
@@ -1,7 +1,8 @@
 @page learn-typescript/configuration Configuration
 @parent learn-typescript 4
+@hide
 
-@description Learn about TypeScript Configurations and Linting
+@description Learn about TypeScript configuration and linting.
 
 @body
 
@@ -113,4 +114,4 @@ For more information on TypeScript with ESLint, we can refer to the [typescript-
 
 ## Next steps
 
-Next we will learn how to [import and export](./exporting-and-importing.html) functions between modules.
+Next we will learn how to import and export functions between [learn-typescript/modules].


### PR DESCRIPTION
I don’t think we need it in the training. There’s no harm in hiding it until we know for sure.