### PR TITLE
Minor updates to the “Introduction to Testing” page

### DIFF
--- a/src/react-native/05-intro-to-testing/EmailInputField.test.1.tsx
+++ b/src/react-native/05-intro-to-testing/EmailInputField.test.1.tsx
@@ -1,0 +1,5 @@
+it("renders the correct label and value", () => {
+    render(<EmailInputField label="Email" value="test@example.com" />)
+    const label = screen.getByText("Email:", { exact: false })
+    expect(label).toBeOnTheScreen()
+})

--- a/src/react-native/05-intro-to-testing/EmailInputField.test.2.tsx
+++ b/src/react-native/05-intro-to-testing/EmailInputField.test.2.tsx
@@ -1,0 +1,9 @@
+it("renders the correct label and value", () => {
+    render(<EmailInputField label="Email" value="test@example.com" />)
+    const label = screen.getByText("Email:", { exact: false })
+    expect(label).toBeOnTheScreen()
+
+    // Validate the input value.
+    const input = screen.getByDisplayValue("test@example.com")
+    expect(input).toBeOnTheScreen()
+})

--- a/src/react-native/05-intro-to-testing/EmailInputField.tsx
+++ b/src/react-native/05-intro-to-testing/EmailInputField.tsx
@@ -1,0 +1,19 @@
+const EmailInputField: FC<Props> = ({ label, value }) => {
+    const [formValue, setFormValue] = useState(value)
+  
+    return (
+      <Box>
+        <Text nativeID="formLabel">
+          {label}:
+        </Text>
+        <TextInput
+          accessibilityLabel="input"
+          accessibilityLabelledBy="formLabel"
+          value={formValue}
+          onChangeText={setFormValue}
+        />
+      </Box>
+    )
+  }
+  
+  <EmailInputField label="Email" value="test@example.com" />

--- a/src/react-native/05-intro-to-testing/intro-to-testing.md
+++ b/src/react-native/05-intro-to-testing/intro-to-testing.md
@@ -36,61 +36,26 @@ RNTL encourages tests that focus on how the user interacts with the application,
 
 OK, you’re convinced that RNTL is a good idea, how do you use it to create tests for your components?
 
-Let’s take a look at an example, say we want to test a component we created named `EmailInputField`.
+Let’s take a look at an example.
+Say we want to test a component we created named `EmailInputField`.
 
-```jsx
-const EmailInputField: FC<Props> = ({ label, value }) => {
-  const [formValue, setFormValue] = useState(value)
+@sourceref ./EmailInputField.tsx
 
-  return (
-    <Box>
-      <Text nativeID="formLabel">
-        {label}:
-      </Text>
-      <TextInput
-        accessibilityLabel="input"
-        accessibilityLabelledBy="formLabel"
-        value={formValue}
-        onChangeText={setFormValue}
-      />
-    </Box>
-  )
-}
-
-<EmailInputField label="Email" value="test@example.com" />
-```
-
-We want to test `EmailInputField`. If you’re already familiar with testing frontend JavaScript code, the following pattern will probably be recognizable: each test consists of arguments to the `it` function provided by Jest. The first argument is a short description of what the test is verifying. The convention is that the description string takes "it" as a prefix and proceeds from there, e.g. "[it] renders the correct label and value."
+We want to test `EmailInputField`. If you have experience with software testing, the following pattern will probably be recognizable: each test consists of arguments to the `it` function provided by Jest. The first argument is a short description of what the test is verifying. The convention is that the description string takes "it" as a prefix and proceeds from there, e.g. "[it] renders the correct label and value."
 
 The second argument to `it` is a callback function that is called to run the test. Inside the callback, invoke the React Native Testing Library function `render` and pass it a single argument, the JSX for your component including props. After `render` completes, use `screen` to query the React Test Renderer and make assertions about the result.
 
-```tsx
-it("renders the correct label and value", () => {
-  render(<EmailInputField label="Email" value="test@example.com" />)
-  const label = screen.getByText("Email:", {exact: false})
-  expect(label).toBeOnTheScreen()
-})
-```
+@sourceref ./EmailInputField.test.1.tsx
 
-In the test above, we validate that the label is correct. We use the `getByText` function to select a single element whose `textContent` matches the string, "Email:". If you look closely you can see that the `<Text nativeId="formLabel">` content in the component has a ":" (colon) at the end, but the `label` prop does not, we can conclude that EmailInputField appends the colon — but **the purpose of the test isn’t how EmailInputField works, it’s the screen output that it returns**. 
+In the test above, we validate that the label is correct. We use the `getByText` function to select a single element whose `textContent` matches the string, "Email:". If you look closely you can see that the `<Text nativeId="formLabel">` content in the component has a ":" (colon) at the end, but the `label` prop does not, we can conclude that `EmailInputField` appends the colon — but **the purpose of the test isn’t how `EmailInputField` works, it’s the screen output that it returns.**
 
-In addition, we add `{exact: false}` as a second argument for getByText. This will ignore extra spaces created by the component from formatting and only match focus on matching the provided text.  
+In addition, we add `{exact: false}` as a second argument for `getByText`. This will ignore extra spaces created by the component from formatting and only match focus on matching the provided text.  
 
 After we get an element, we then use `expect` and `toBeOnTheScreen` to verify the element was rendered properly. Our test passes because the generated screen is what we expect the user will perceive.
 
 We also want to validate the `<input>` element; let’s update the test:
 
-```tsx
-it("renders the correct label and value", () => {
-  render(<EmailInputField label="Email" value="test@example.com" />)
-  const label = screen.getByText("Email:", {exact: false})
-  expect(label).toBeOnTheScreen()
-
-  // Validate the input value.
-  const input = screen.getByDisplayValue("test@example.com")
-  expect(input).toBeOnTheScreen()
-})
-```
+@diff ./EmailInputField.test.1.tsx ./EmailInputField.test.2.tsx only
 
 We’ve used a different query to select the `<TextInput>` element: `getByDisplayValue`. It returns an input element whose value matches the provided string. RNTL uses React Testing Libraries Core API which has a [suite of "query" functions](https://testing-library.com/docs/queries/about) that select elements based on characteristics like: role, label text, placeholder text, text, display value, alt text, and title. Our test continues to pass because the input’s value in the screen matches what we expect.
 
@@ -98,7 +63,7 @@ We’ve used a different query to select the `<TextInput>` element: `getByDispla
 
 Most components can respond to events raised by user interaction, like clicking a button. How can we test code that responds to these interactions? We use another RNTL package named [user-event](https://callstack.github.io/react-native-testing-library/docs/user-event).
 
-`user-event` allows your tests to interact with your component in a browser-like manner, where a single user action can raise multiple events. For example, when a button is clicked, it can emit a focus event and then a click event. `user-event` also has some helpful functionality to prevent interactions that are not possible in a browser environment, such as not firing a click event from an element that’s hidden.
+The `user-event` package allows your tests to interact with your component in a way that more closely matches what would happen with real user interactions, where a single user action can raise multiple events. For example, when a button is clicked, it can emit a focus event and then a click event. `user-event` also has some helpful functionality to prevent interactions that users would not realistically be able to do, such as not firing a click event from an element that’s hidden.
 
 All of the methods provided by `user-event` return a Promise, so we want to prefix the test callback function with `async` and use `await` when a `user-event` method is called.
 
@@ -106,25 +71,7 @@ All of the methods provided by `user-event` return a Promise, so we want to pref
 
 Referring back to the `EmailInputField` component:
 
-```jsx
-const EmailInputField: FC<Props> = ({ label, value }) => {
-  const [formValue, setFormValue] = useState(value)
-
-  return (
-    <Box>
-      <Text nativeID="formLabel">
-        {label}:
-      </Text>
-      <TextInput
-        accessibilityLabel="input"
-        accessibilityLabelledBy="formLabel"
-        value={formValue}
-        onChangeText={setFormValue}
-      />
-    </Box>
-  )
-}
-```
+@sourceref ./EmailInputField.tsx
 
 We want to write a test to verify that what the user types is displayed as the `<TextInput>`’s value. The user-event library includes a method named `type` that we can use to send a sequence of key events to the `<TextInput>` element. The `type` method provides a good simulation of what happens when a user is typing. Before we use `type` in a test, we need to [initialize user events with the `setup` method](https://callstack.github.io/react-native-testing-library/docs/user-event#setup). Let’s look at the test:
 
@@ -132,18 +79,18 @@ We want to write a test to verify that what the user types is displayed as the `
 import { userEvent, render, screen } from "@testing-library/react-native"
 import EmailInputField from "./EmailInputField"
 
-  it("renders label", async () => {
-    const user = userEvent.setup()
+it("renders label", async () => {
+  const user = userEvent.setup()
 
-    render(<EmailInputField label="Email" value="" />)
+  render(<EmailInputField label="Email" value="" />)
 
-    const input = screen.getByLabelText("Email:")
-    expect(input).toBeOnTheScreen()
-    expect(input).toHaveDisplayValue("")
+  const input = screen.getByLabelText("Email:")
+  expect(input).toBeOnTheScreen()
+  expect(input).toHaveDisplayValue("")
 
-    await user.type("test@example.com")
-    expect(input).toHaveDisplayValue("test@example.com")
-  })
+  await user.type("test@example.com")
+  expect(input).toHaveDisplayValue("test@example.com")
+})
 ```
 
 There are some notable differences compared to the previous test:


### PR DESCRIPTION
- Move the code examples to files so they’re easier to work with.
- Replace mentions of frontend and browser development (because the learners aren’t expected to know frontend dev).
- Other minor edits.