### PR TITLE
Fix the Pressable example in Making HTTP Requests

### DIFF
--- a/src/react-native/13-making-http-requests/dependency-array-undefined.tsx
+++ b/src/react-native/13-making-http-requests/dependency-array-undefined.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { Pressable, Text } from "react-native";
 
 function UpdateLogger() {
     const [count, setCount] = useState(0);
@@ -8,9 +9,11 @@ function UpdateLogger() {
     }); // No dependency array, runs on every update
 
     return (
-        <button onClick={() => setCount(count + 1)}>
-            Increment
-        </button>
+        <Pressable onPress={() => setCount(count + 1)}>
+            <Text>
+                Increment
+            </Text>
+        </Pressable>
     );
 }
 


### PR DESCRIPTION
Added `<Text>` components inside `<Pressable>` because that’s how it’s actually used.