### PR TITLE
Remove the navigation params from “Navigation”

### DIFF
--- a/exercise-src/react-native/11-navigation/02-problem/src/screens/StateList/StateList.tsx
+++ b/exercise-src/react-native/11-navigation/02-problem/src/screens/StateList/StateList.tsx
@@ -3,7 +3,6 @@ import { FlatList } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 
 import Screen from "../../design/Screen"
-import Typography from "../../design/Typography"
 import Button from "../../design/Button"
 
 export interface State {
@@ -32,9 +31,7 @@ const StateList: FC = () => {
         renderItem={({ item: stateItem }) => (
           <Button
             onPress={() => {
-              navigation.navigate("CityList", {
-                state: stateItem,
-              })
+              navigation.navigate("CityList")
             }}
           >
             {stateItem.name}

--- a/exercise-src/react-native/11-navigation/02-solution/src/App.tsx
+++ b/exercise-src/react-native/11-navigation/02-solution/src/App.tsx
@@ -37,10 +37,7 @@ const RestaurantsNavigator: FC = () => {
               >
                 <Icon name="arrow-back" size={20} />
                 <Typography variant="heading">
-                  {/* @ts-ignore */}
-                  {[route.params?.city?.name, route.params?.state?.name]
-                    .filter(Boolean)
-                    .join(", ")}
+                  Choose a location
                 </Typography>
               </Box>
             </Pressable>

--- a/exercise-src/react-native/11-navigation/02-solution/src/screens/StateList/StateList.tsx
+++ b/exercise-src/react-native/11-navigation/02-solution/src/screens/StateList/StateList.tsx
@@ -3,7 +3,6 @@ import { FlatList } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 
 import Screen from "../../design/Screen"
-import Typography from "../../design/Typography"
 import Button from "../../design/Button"
 
 export interface State {
@@ -32,9 +31,7 @@ const StateList: FC = () => {
         renderItem={({ item: stateItem }) => (
           <Button
             onPress={() => {
-              navigation.navigate("CityList", {
-                state: stateItem,
-              })
+              navigation.navigate("CityList")
             }}
           >
             {stateItem.name}

--- a/exercise-src/react-native/11-navigation/03-problem/src/App.tsx
+++ b/exercise-src/react-native/11-navigation/03-problem/src/App.tsx
@@ -7,8 +7,6 @@ import Icon from "react-native-vector-icons/Ionicons"
 import ThemeProvider, { useTheme } from "./design/theme/ThemeProvider"
 import StateList from "./screens/StateList"
 import Settings from "./screens/Settings"
-import RestaurantDetails from "./screens/RestaurantDetails"
-import RestaurantList from "./screens/RestaurantList"
 import CityList from "./screens/CityList"
 import Box from "./design/Box"
 import Typography from "./design/Typography"
@@ -31,10 +29,7 @@ const RestaurantsNavigator: FC = () => {
               >
                 <Icon name="arrow-back" size={20} />
                 <Typography variant="heading">
-                  {/* @ts-ignore */}
-                  {[route.params?.city?.name, route.params?.state?.name]
-                    .filter(Boolean)
-                    .join(", ")}
+                  Choose a location
                 </Typography>
               </Box>
             </Pressable>

--- a/exercise-src/react-native/11-navigation/03-problem/src/screens/RestaurantDetails/RestaurantDetails.tsx
+++ b/exercise-src/react-native/11-navigation/03-problem/src/screens/RestaurantDetails/RestaurantDetails.tsx
@@ -26,8 +26,7 @@ const restaurant = {
   },
 }
 
-const RestaurantDetails: FC<Props> = ({ route }) => {
-  const { slug } = route.params
+const RestaurantDetails: FC<Props> = () => {
   const navigation = useNavigation()
   useEffect(() => {
     if (restaurant) {

--- a/exercise-src/react-native/11-navigation/03-problem/src/screens/RestaurantList/RestaurantList.tsx
+++ b/exercise-src/react-native/11-navigation/03-problem/src/screens/RestaurantList/RestaurantList.tsx
@@ -42,10 +42,8 @@ const restaurants = [
   },
 ]
 
-const RestaurantList: FC<Props> = ({ route }) => {
+const RestaurantList: FC<Props> = () => {
   const navigation = useNavigation()
-
-  const { state, city } = route.params
 
   const navigateToDetails = (slug: string) => {
     //Exercise: Implement navigation to RestaurantDetails

--- a/exercise-src/react-native/11-navigation/03-solution/src/App.tsx
+++ b/exercise-src/react-native/11-navigation/03-solution/src/App.tsx
@@ -31,10 +31,7 @@ const RestaurantsNavigator: FC = () => {
               >
                 <Icon name="arrow-back" size={20} />
                 <Typography variant="heading">
-                  {/* @ts-ignore */}
-                  {[route.params?.city?.name, route.params?.state?.name]
-                    .filter(Boolean)
-                    .join(", ")}
+                  Choose a location
                 </Typography>
               </Box>
             </Pressable>

--- a/exercise-src/react-native/11-navigation/03-solution/src/screens/RestaurantDetails/RestaurantDetails.tsx
+++ b/exercise-src/react-native/11-navigation/03-solution/src/screens/RestaurantDetails/RestaurantDetails.tsx
@@ -5,7 +5,6 @@ import { useEffect } from "react"
 import { useNavigation } from "@react-navigation/native"
 
 import RestaurantHeader from "../../components/RestaurantHeader"
-import Button from "../../design/Button"
 import Screen from "../../design/Screen"
 
 export type Props = StaticScreenProps<{
@@ -27,8 +26,7 @@ const restaurant = {
   },
 }
 
-const RestaurantDetails: FC<Props> = ({ route }) => {
-  const { slug } = route.params
+const RestaurantDetails: FC<Props> = () => {
   const navigation = useNavigation()
   useEffect(() => {
     if (restaurant) {
@@ -39,14 +37,6 @@ const RestaurantDetails: FC<Props> = ({ route }) => {
   return (
     <Screen>
       <RestaurantHeader restaurant={restaurant} />
-
-      <Button
-        onPress={() => {
-          navigation.navigate("OrderCreate", { slug: slug })
-        }}
-      >
-        Place an order
-      </Button>
     </Screen>
   )
 }

--- a/exercise-src/react-native/11-navigation/03-solution/src/screens/RestaurantList/RestaurantList.tsx
+++ b/exercise-src/react-native/11-navigation/03-solution/src/screens/RestaurantList/RestaurantList.tsx
@@ -42,17 +42,11 @@ const restaurants = [
   },
 ]
 
-const RestaurantList: FC<Props> = ({ route }) => {
+const RestaurantList: FC<Props> = () => {
   const navigation = useNavigation()
 
-  const { state, city } = route.params
-
-  const navigateToDetails = (slug: string) => {
-    navigation.navigate("RestaurantDetails", {
-      state,
-      city,
-      slug,
-    })
+  const navigateToDetails = () => {
+    navigation.navigate("RestaurantDetails")
   }
 
   return (


### PR DESCRIPTION
This updates the exercises for the “Navigation” module by removing 1) the parameters that were passed in `navigation.navigate()` calls and 2) the route props that were passed into components.

All of the navigation parameter-related code will be covered in “Storing State in Navigation Parameters,”