### PR TITLE
Make the exercise test command more resilient to failures

### DIFF
--- a/exercises/tests.mjs
+++ b/exercises/tests.mjs
@@ -43,6 +43,8 @@ async function processSolutions(pageDirectory) {
         const relativeDirectory = path.relative(import.meta.dirname, solutionDirectory)
         const packageJsonPath = path.join(solutionDirectory, 'package.json');
         if (fs.existsSync(packageJsonPath)) {
+            console.info(`Found package.json in ${relativeDirectory}`);
+
             const { scripts } = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
             const script = 'test';
             if (!scripts[script]) {
@@ -50,10 +52,13 @@ async function processSolutions(pageDirectory) {
                 continue;
             }
 
-            console.info(`Found package.json in ${relativeDirectory}`);
             await executeCommand('npm ci', solutionDirectory);
             await executeCommand(`npm run ${script}`, solutionDirectory);
-            await executeCommand('rm -rf node_modules', solutionDirectory);
+            try {
+                await executeCommand('rm -rf node_modules', solutionDirectory);
+            } catch (error) {
+                console.warn('Ignoring error while deleting node_modules:', error);
+            }
             console.info("");
         }
     }


### PR DESCRIPTION
I sometimes run into issues with the test script where it is unable to delete the `node_modules` folder after running an exercise solution’s test.

Since this step is not critical to whether the tests have passed or not, these errors will now be caught and logged, but ignored so the script can keep running.

I’d like to look into why I’m seeing these failures, but in the meantime, I think this improves the script for anyone else who might run into a similar issue.