### PR TITLE
Fix keyPrefix being added to early

### DIFF
--- a/exercise-src/react-native/13-http-requests/03-problem/src/services/pmo/api/api.ts
+++ b/exercise-src/react-native/13-http-requests/03-problem/src/services/pmo/api/api.ts
@@ -1,7 +1,5 @@
 const baseUrl = process.env.PMO_API
 
-export const keyPrefix = "apiRequest-"
-
 export async function apiRequest<
   Data = never,
   Params = unknown,

--- a/exercise-src/react-native/13-http-requests/03-solution/src/services/pmo/api/api.ts
+++ b/exercise-src/react-native/13-http-requests/03-solution/src/services/pmo/api/api.ts
@@ -1,7 +1,5 @@
 const baseUrl = process.env.PMO_API
 
-export const keyPrefix = "apiRequest-"
-
 export async function apiRequest<
   Data = never,
   Params = unknown,


### PR DESCRIPTION
The `keyPrefix` isn’t needed until Async Storage, so this removes it from the earlier exercise code.