### PR TITLE
Run the tests in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,21 @@ If a `node_modules` folder is left inside `src`, it will be processed as content
 
 ### Testing the exercises
 
-The test script will look inside the `exercises` folder folder any `-solution` folder that has a `package.json`, then install the dependencies and run the tests:
+The test script will look inside the `exercises` folder for any `-solution` folder that has a `package.json`, then install the dependencies and run the tests:
 
 ```sh
 npm test
 ```
+
+It will run up to three of the tests in parallel at a time. This is set in the test script.
+
+To benchmark how many parallel tests can be run at a time, run:
+
+```sh
+npm run test:benchmark
+```
+
+This command will run the tests with various levels of parallelism and print the results at the end.
 
 ### Building
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lint:fix": "npm run lint:content:fix && npm run lint:exercises:fix",
     "rebuild-assets": "bit-docs -dfs",
     "start": "concurrently -k \"npm:dev\" \"http-server -c -1\"",
-    "test": "node ./exercises/tests.mjs"
+    "test": "node ./exercises/tests.mjs",
+    "test:benchmark": "node ./exercises/tests.mjs --benchmark"
   },
   "bit-docs": {
     "dependencies": {


### PR DESCRIPTION
This improves the time it takes to run the exercise solution tests by running them in parallel.

Below are the results of multiple test runs in GitHub and on a MacBook Pro. It looks like about three tests running in parallel is optimal in both environments, so the `test` script will max out at running three tests at a time.

First run in GitHub CI:

```
┌─────────┬───────┬───────────────┬─────────────┐
│ (index) │ limit │ time          │ formatted   │
├─────────┼───────┼───────────────┼─────────────┤
│ 0       │ 4     │ 787608.631378 │ '13:07.608' │
│ 1       │ 3     │ 461751.497619 │ '7:41.751'  │
│ 2       │ 2     │ 475695.005603 │ '7:55.695'  │
│ 3       │ 1     │ 646006.242796 │ '10:46.006' │
└─────────┴───────┴───────────────┴─────────────┘
```

Second run (after changing the max limit after realizing the first run will be slower while priming the npm cache):

```
┌─────────┬───────┬───────────────┬─────────────┐
│ (index) │ limit │ time          │ formatted   │
├─────────┼───────┼───────────────┼─────────────┤
│ 0       │ 5     │ 763990.330012 │ '12:43.990' │
│ 1       │ 4     │ 432908.429822 │ '7:12.908'  │
│ 2       │ 3     │ 445064.747047 │ '7:25.064'  │
│ 3       │ 2     │ 468414.323292 │ '7:48.414'  │
│ 4       │ 1     │ 639965.18994  │ '10:39.965' │
└─────────┴───────┴───────────────┴─────────────┘
```

First run on a MacBook Pro:

```
┌─────────┬───────┬───────────────┬─────────────┐
│ (index) │ limit │ time          │ formatted   │
├─────────┼───────┼───────────────┼─────────────┤
│ 0       │ 8     │ 666539.938417 │ '11:06.539' │
│ 1       │ 7     │ 607849.072083 │ '10:07.849' │
│ 2       │ 6     │ 571706.310166 │ '9:31.706'  │
│ 3       │ 5     │ 516670.640167 │ '8:36.670'  │
│ 4       │ 4     │ 498700.136167 │ '8:18.700'  │
│ 5       │ 3     │ 471225.195584 │ '7:51.225'  │
│ 6       │ 2     │ 485589.121083 │ '8:05.589'  │
│ 7       │ 1     │ 617190.439583 │ '10:17.190' │
└─────────┴───────┴───────────────┴─────────────┘
```

Second run:

```
┌─────────┬───────┬───────────────┬─────────────┐
│ (index) │ limit │ time          │ formatted   │
├─────────┼───────┼───────────────┼─────────────┤
│ 0       │ 8     │ 653896.0615   │ '10:53.896' │
│ 1       │ 7     │ 578432.966958 │ '9:38.432'  │
│ 2       │ 6     │ 550287.004208 │ '9:10.287'  │
│ 3       │ 5     │ 509471.244167 │ '8:29.471'  │
│ 4       │ 4     │ 497503.24975  │ '8:17.503'  │
│ 5       │ 3     │ 468895.376833 │ '7:48.895'  │
│ 6       │ 2     │ 492863.924542 │ '8:12.863'  │
│ 7       │ 1     │ 615069.0665   │ '10:15.069' │
└─────────┴───────┴───────────────┴─────────────┘
```