### PR TITLE
Improve the content & exercises for “Introduction to JSX”

### DIFF
--- a/exercise-src/react-native/03-creating-a-new-app/02-solution/App.tsx
+++ b/exercise-src/react-native/03-creating-a-new-app/02-solution/App.tsx
@@ -1,15 +1,8 @@
-import type { JSX } from "react"
-import {SafeAreaView, ScrollView, Text, View} from 'react-native';
+import {Text} from 'react-native';
 
-function App(): JSX.Element {
+const App: React.FC = () => {
   return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <ScrollView>
-        <View>
-          <Text>Place My Order: Coming Soon!</Text>
-        </View>
-      </ScrollView>
-    </SafeAreaView>
+    <Text>Place My Order: Coming Soon!</Text>
   );
 }
 

--- a/exercise-src/react-native/03-creating-a-new-app/03-solution/App.tsx
+++ b/exercise-src/react-native/03-creating-a-new-app/03-solution/App.tsx
@@ -1,15 +1,7 @@
-import { SafeAreaView, ScrollView, Text, View } from "react-native"
+import { Text } from "react-native"
 
 const App: React.FC = () => {
-  return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <ScrollView>
-        <View>
-          <Text>Place My Order: Coming Soon!</Text>
-        </View>
-      </ScrollView>
-    </SafeAreaView>
-  )
+  return <Text>Place My Order: Coming Soon!</Text>
 }
 
 export default App

--- a/exercise-src/react-native/04-intro-to-jsx/01-problem/App.tsx
+++ b/exercise-src/react-native/04-intro-to-jsx/01-problem/App.tsx
@@ -1,17 +1,7 @@
 import { SafeAreaView, ScrollView, Text, View } from "react-native"
 
-const state = { name: "Illinois", short: "IL" }
-
 const App: React.FC = () => {
-  return (
-    <SafeAreaView style={{ flex: 1 }}>
-      <ScrollView>
-        <View>
-          <Text>Place My Order: Coming Soon!</Text>
-        </View>
-      </ScrollView>
-    </SafeAreaView>
-  )
+  return <Text>Place My Order: Coming Soon!</Text>
 }
 
 export default App

--- a/exercise-src/react-native/04-intro-to-jsx/01-solution/App.tsx
+++ b/exercise-src/react-native/04-intro-to-jsx/01-solution/App.tsx
@@ -1,7 +1,5 @@
 import { SafeAreaView, ScrollView, Text, View } from "react-native"
 
-const state = { name: "Illinois", short: "IL" }
-
 const App: React.FC = () => {
   return (
     <SafeAreaView style={{ flex: 1 }}>
@@ -10,7 +8,7 @@ const App: React.FC = () => {
           <Text>Place My Order: Coming Soon!</Text>
         </View>
         <View>
-          <Text>{state.name}</Text>
+          <Text>Illinois</Text>
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/exercise-src/react-native/04-intro-to-jsx/02-problem/App.tsx
+++ b/exercise-src/react-native/04-intro-to-jsx/02-problem/App.tsx
@@ -19,7 +19,7 @@ const App: React.FC = () => {
           <Text>Place My Order: Coming Soon!</Text>
         </View>
         <View>
-          <Text>{states[0].name}</Text>
+          <Text>Illinois</Text>
         </View>
       </ScrollView>
     </SafeAreaView>

--- a/src/react-native/04-intro-to-jsx/SafeAreaView.tsx
+++ b/src/react-native/04-intro-to-jsx/SafeAreaView.tsx
@@ -1,0 +1,11 @@
+import { SafeAreaView, Text } from "react-native"
+
+const App: React.FC = () => {
+  return (
+    <SafeAreaView style={{ flex: 1 }}>
+      <Text>Content within safe area.</Text>
+    </SafeAreaView>
+  )
+}
+
+export default App

--- a/src/react-native/04-intro-to-jsx/ScrollView.tsx
+++ b/src/react-native/04-intro-to-jsx/ScrollView.tsx
@@ -1,0 +1,16 @@
+import { ScrollView, Text } from "react-native"
+
+const App: React.FC = () => {
+  return (
+    <ScrollView>
+      <Text>Ada Lovelace</Text>
+      <Text>Grace Hopper</Text>
+      <Text>Katherine Johnson</Text>
+      <Text>Margaret Hamilton</Text>
+      <Text>Radia Perlman</Text>
+      <Text>Hedy Lamarr</Text>
+    </ScrollView>
+  )
+}
+
+export default App

--- a/src/react-native/04-intro-to-jsx/View.tsx
+++ b/src/react-native/04-intro-to-jsx/View.tsx
@@ -1,0 +1,11 @@
+import { Text, View } from "react-native"
+
+const App: React.FC = () => {
+  return (
+    <View>
+      <Text>Hello, React Native!</Text>
+    </View>
+  )
+}
+
+export default App

--- a/src/react-native/04-intro-to-jsx/intro-to-jsx.md
+++ b/src/react-native/04-intro-to-jsx/intro-to-jsx.md
@@ -132,6 +132,37 @@ const content = <Text style={{ fontStyle: "italic" }}>Restaurants</Text>
 
 As we go through this training, you’ll learn additional differences.
 
+#### Using `View`
+
+The `View` component is one of the most fundamental building blocks in React Native.
+It is a container component that can hold one or more other components while grouping them together for accessibility, styling, touch handling, and more.
+
+If you’re familiar with web development, a `<View>` is similar to a `<div>`.
+
+@sourceref ./View.tsx
+@highlight 5, 7, only
+
+#### Using `ScrollView`
+
+The `ScrollView` component is a generic scrolling container that can host multiple components and views.
+It is useful when the content you need to display exceeds the screen size, enabling vertical or horizontal scrolling.
+
+@sourceref ./ScrollView.tsx
+@highlight 5, 12, only
+
+#### Using `SafeAreaView`
+
+The `SafeAreaView` component ensures that the content is rendered within the safe area boundaries of a device.
+This is particularly important for devices with notches, home indicators, or rounded corners.
+
+@sourceref ./SafeAreaView.tsx
+@highlight 5, 7, only
+
+You’ll notice the `flex: 1` style that we’ve added to the component.
+We will get into styles more later, but for now, know that `flex: 1` will make the component take up all the available space.
+
+In general, you always want to have your content wrapped in a `<SafeAreaView>` so the device’s hardware boundaries don’t overlap with your app’s content.
+
 #### Parenthesis (convention)
 
 When dealing with JSX that needs multiple lines, the convention is to wrap it in parentheses. This helps keep your JSX clean and clear, rather than mixing it with the Javascript around it.
@@ -165,18 +196,6 @@ function List() {
 }
 ```
 
-#### Using `View`
-
-TODO: Introduce this core component.
-
-#### Using `ScrollView`
-
-TODO: Introduce this core component.
-
-#### Using `SafeAreaView`
-
-TODO: Introduce this core component.
-
 ### Setup 1
 
 ✏️ Update **App.tsx** to be:
@@ -191,7 +210,10 @@ TODO: Introduce this core component.
 
 ### Exercise 1
 
-Use JSX to dynamically display a state name from a variable that’s an object.
+Update `App.tsx` to include the following:
+
+- Use `SafeAreaView`, `ScrollView`, and `View` to wrap the existing `Text` component.
+- Add a new `View` component to wrap `Text` that says “Illinois”.
 
 ### Solution 1
 


### PR DESCRIPTION
This rearranges some of the exercise code across the “Create a New App” and “Intro to JSX” pages:

- “Create a New App” now only uses `<Text>`
- “Intro to JSX” (objective 1) introduces the `View`, `ScrollView`, and `SafeArea` components.
- The first exercise has learners use those components.

This fixes the issue that Objective 1’s exercise had learners use interpolation, which hadn’t been taught yet.