### PR TITLE
Fix CRLF issues with Prettier

### DIFF
--- a/exercise-src/react-native/.prettierrc.js
+++ b/exercise-src/react-native/.prettierrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  endOfLine: "auto",
   semi: false,
   trailingComma: "all",
 }

--- a/exercise-src/react-native/03-creating-a-new-app/03-solution/.prettierrc.js
+++ b/exercise-src/react-native/03-creating-a-new-app/03-solution/.prettierrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  endOfLine: "auto",
   semi: false,
   trailingComma: "all",
 }

--- a/src/react-native/.prettierrc.js
+++ b/src/react-native/.prettierrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  endOfLine: "auto",
   semi: false,
   trailingComma: "all",
 }


### PR DESCRIPTION
This adds `endOfLine: "auto"` to the Prettier config so CRLF line endings are respected on Windows.