### PR TITLE
Improve the “Introduction to Testing” page

### DIFF
--- a/src/react-native/05-intro-to-testing/EmailInputField.test.1.tsx
+++ b/src/react-native/05-intro-to-testing/EmailInputField.test.1.tsx
@@ -1,3 +1,7 @@
+import { render, screen } from "@testing-library/react-native"
+
+import EmailInputField from "./EmailInputField"
+
 it("renders the correct label and value", () => {
   render(<EmailInputField label="Email" value="test@example.com" />)
   const label = screen.getByText("Email:", { exact: false })

--- a/src/react-native/05-intro-to-testing/EmailInputField.test.2.tsx
+++ b/src/react-native/05-intro-to-testing/EmailInputField.test.2.tsx
@@ -1,3 +1,7 @@
+import { render, screen } from "@testing-library/react-native"
+
+import EmailInputField from "./EmailInputField"
+
 it("renders the correct label and value", () => {
   render(<EmailInputField label="Email" value="test@example.com" />)
   const label = screen.getByText("Email:", { exact: false })

--- a/src/react-native/05-intro-to-testing/EmailInputField.test.3.tsx
+++ b/src/react-native/05-intro-to-testing/EmailInputField.test.3.tsx
@@ -1,0 +1,26 @@
+import { render, screen, userEvent } from "@testing-library/react-native"
+
+import EmailInputField from "./EmailInputField"
+
+it("renders the correct label and value", () => {
+  render(<EmailInputField label="Email" value="test@example.com" />)
+  const label = screen.getByText("Email:", { exact: false })
+  expect(label).toBeOnTheScreen()
+
+  // Validate the input value.
+  const input = screen.getByDisplayValue("test@example.com")
+  expect(input).toBeOnTheScreen()
+})
+
+it("updates when an email is entered", async () => {
+  const user = userEvent.setup()
+
+  render(<EmailInputField label="Email" value="" />)
+
+  const input = screen.getByLabelText("Email:")
+  expect(input).toBeOnTheScreen()
+  expect(input).toHaveDisplayValue("")
+
+  await user.type(input, "test@example.com")
+  expect(input).toHaveDisplayValue("test@example.com")
+})

--- a/src/react-native/05-intro-to-testing/EmailInputField.tsx
+++ b/src/react-native/05-intro-to-testing/EmailInputField.tsx
@@ -1,8 +1,11 @@
+import { useState } from "react"
+import { SafeAreaView, ScrollView, Text, TextInput, View } from "react-native"
+
 const EmailInputField: React.FC<Props> = ({ label, value }) => {
   const [formValue, setFormValue] = useState(value)
 
   return (
-    <Box>
+    <View>
       <Text nativeID="formLabel">{label}:</Text>
       <TextInput
         accessibilityLabel="input"
@@ -10,8 +13,18 @@ const EmailInputField: React.FC<Props> = ({ label, value }) => {
         value={formValue}
         onChangeText={setFormValue}
       />
-    </Box>
+    </View>
   )
 }
 
-const content = <EmailInputField label="Email" value="test@example.com" />
+const App: React.FC = () => {
+  return (
+    <SafeAreaView style={{ flex: 1 }}>
+      <ScrollView>
+        <EmailInputField label="Email" value="test@example.com" />
+      </ScrollView>
+    </SafeAreaView>
+  )
+}
+
+export default App

--- a/src/react-native/05-intro-to-testing/EmailInputField.xml
+++ b/src/react-native/05-intro-to-testing/EmailInputField.xml
@@ -1,0 +1,14 @@
+<RCTSafeAreaView>
+  <RCTScrollView>
+    <View>
+      <View>
+        <Text nativeID="formLabel">Email :</Text>
+        <TextInput
+          accessibilityLabel="input"
+          accessibilityLabelledBy="formLabel"
+          value="test@example.com"
+        />
+      </View>
+    </View>
+  </RCTScrollView>
+</RCTSafeAreaView>

--- a/src/react-native/05-intro-to-testing/intro-to-testing.md
+++ b/src/react-native/05-intro-to-testing/intro-to-testing.md
@@ -12,7 +12,7 @@ In this section, you will:
 
 - Learn about React Native Testing Library.
 - See the distinctions of testing for React Native components.
-- Use userEvent from `@testing-library/react-native` to simulate user interactions
+- Use `userEvent` from `@testing-library/react-native` to simulate user interactions.
 
 ## Objective 1: Testing in React Native
 
@@ -22,11 +22,12 @@ Testing helps by verifying that given certain inputs our code generates expected
 
 ### Introducing React Native Testing Library
 
-[React Native Testing Library (RNTL)](https://callstack.github.io/react-native-testing-library/docs/getting-started) is a set of tools that helps us write robust tests for our React Native applications. Unlike some other testing libraries that focus on the internal state and implementation details of components, RNTL emphasizes testing the behavior of components as experienced by the end users.
+[React Native Testing Library (RNTL)](https://callstack.github.io/react-native-testing-library/docs/getting-started) is a set of tools that helps us write robust tests for our React Native applications.
+Unlike some other testing libraries that focus on the internal state and implementation details of components, RNTL emphasizes testing the user interface (UI) behavior as experienced by the end users.
 
-In order to test components, it provides light utility functions using React Test Renderer. Most testing libraries use the DOM, but since React Native doesn't use the DOM, the React Test Renderer is necessary.
+In order to test components, it provides light utility functions using React Test Renderer. Most testing libraries use the DOM, but since React Native doesn’t use the DOM, the React Test Renderer is necessary.
 
-Akin to the original React Testing Library, RNTL's north star is:
+Akin to the original React Testing Library, RNTL’s north star is:
 
 > The more your tests resemble the way your software is used, the more confidence they can give you.
 
@@ -40,7 +41,12 @@ Let’s take a look at an example.
 Say we want to test a component we created named `EmailInputField`.
 
 @sourceref ./EmailInputField.tsx
-@highlight 20, only
+@highlight 4, 8-16, 24, only
+
+When rendered by React Native, this JSX will look something like:
+
+@sourceref ./EmailInputField.xml
+@highlight 4-11, only
 
 We want to test `EmailInputField`. If you have experience with software testing, the following pattern will probably be recognizable: each test consists of arguments to the `it` function provided by Jest. The first argument is a short description of what the test is verifying. The convention is that the description string takes "it" as a prefix and proceeds from there, e.g. "[it] renders the correct label and value."
 
@@ -48,23 +54,31 @@ The second argument to `it` is a callback function that is called to run the tes
 
 @sourceref ./EmailInputField.test.1.tsx
 
-In the test above, we validate that the label is correct. We use the `getByText` function to select a single element whose `textContent` matches the string, "Email:". If you look closely you can see that the `<Text nativeId="formLabel">` content in the component has a ":" (colon) at the end, but the `label` prop does not, we can conclude that `EmailInputField` appends the colon — but **the purpose of the test isn’t how `EmailInputField` works, it’s the screen output that it returns.**
+In the test above, we validate that the label is correct.
+We use the `getByText` function to select a single component whose text matches the string, `"Email:"`.
+If you look closely, you can see that the `<Text nativeID="formLabel">` content in the component has a `":"` (colon) at the end, but the `label` prop does not, so we can conclude that `EmailInputField` appends the colon — but **the purpose of the test isn’t how EmailInputField works, it’s the output that it returns.**
 
 In addition, we add `{exact: false}` as a second argument for `getByText`. This will ignore extra spaces created by the component from formatting and only match focus on matching the provided text.
 
-After we get an element, we then use `expect` and `toBeOnTheScreen` to verify the element was rendered properly. Our test passes because the generated screen is what we expect the user will perceive.
+After we get a component, we then use `expect` and `toBeOnTheScreen` to verify the component was rendered properly. Our test passes because the generated screen is what we expect the user will perceive.
 
-We also want to validate the `<input>` element; let’s update the test:
+We also want to validate the `<TextInput>` component; let’s update the test:
 
 @diff ./EmailInputField.test.1.tsx ./EmailInputField.test.2.tsx only
 
-We’ve used a different query to select the `<TextInput>` element: `getByDisplayValue`. It returns an input element whose value matches the provided string. RNTL uses React Testing Libraries Core API which has a [suite of "query" functions](https://testing-library.com/docs/queries/about) that select elements based on characteristics like: role, label text, placeholder text, text, display value, alt text, and title. Our test continues to pass because the input’s value in the screen matches what we expect.
+We’ve used a different query to select the `<TextInput>` component: `getByDisplayValue`.
+It returns an input component whose value matches the provided string.
+RNTL uses React Testing Libraries Core API which has a [suite of "query" functions](https://testing-library.com/docs/queries/about) that select components based on characteristics like: role, label text, text, display value, and title.
+Our test continues to pass because the input’s value in the screen matches what we expect.
 
 ## Objective 2: Write a test for handling user interactions
 
-Most components can respond to events raised by user interaction, like clicking a button. How can we test code that responds to these interactions? We use another RNTL package named [user-event](https://callstack.github.io/react-native-testing-library/docs/user-event).
+Most components can respond to events raised by user interaction, like tapping a button.
+How can we test code that responds to these interactions?
 
-The `user-event` package allows your tests to interact with your component in a way that more closely matches what would happen with real user interactions, where a single user action can raise multiple events. For example, when a button is clicked, it can emit a focus event and then a click event. `user-event` also has some helpful functionality to prevent interactions that users would not realistically be able to do, such as not firing a click event from an element that’s hidden.
+The `userEvent` API provided by RNTL allows your tests to interact with your component in a way that more closely matches what would happen with real user interactions, where a single user action can raise multiple events.
+For example, when a text input is typed into, it can emit focus and input events.
+The `userEvent` API also has some helpful functionality to prevent interactions that users would not realistically be able to do, such as not firing events from a component that’s hidden.
 
 All of the methods provided by `user-event` return a Promise, so we want to prefix the test callback function with `async` and use `await` when a `user-event` method is called.
 
@@ -73,30 +87,19 @@ All of the methods provided by `user-event` return a Promise, so we want to pref
 Referring back to the `EmailInputField` component:
 
 @sourceref ./EmailInputField.tsx
+@highlight 4-5, 10-15, only
 
-We want to write a test to verify that what the user types is displayed as the `<TextInput>`’s value. The user-event library includes a method named `type` that we can use to send a sequence of key events to the `<TextInput>` element. The `type` method provides a good simulation of what happens when a user is typing. Before we use `type` in a test, we need to [initialize user events with the `setup` method](https://callstack.github.io/react-native-testing-library/docs/user-event#setup). Let’s look at the test:
+We want to write a test to verify that what the user types is displayed as the `<TextInput>`’s value.
+The `userEvent` API includes a method named `type` that we can use to send a sequence of key events to the `<TextInput>` component.
+The `type` method provides a good simulation of what happens when a user is typing.
+Before we use `type` in a test, we need to [initialize user events with the `setup` method](https://callstack.github.io/react-native-testing-library/docs/user-event#setup).
+Let’s look at the test:
 
-```tsx
-import { userEvent, render, screen } from "@testing-library/react-native"
-import EmailInputField from "./EmailInputField"
-
-it("renders label", async () => {
-  const user = userEvent.setup()
-
-  render(<EmailInputField label="Email" value="" />)
-
-  const input = screen.getByLabelText("Email:")
-  expect(input).toBeOnTheScreen()
-  expect(input).toHaveDisplayValue("")
-
-  await user.type("test@example.com")
-  expect(input).toHaveDisplayValue("test@example.com")
-})
-```
+@diff ./EmailInputField.test.2.tsx ./EmailInputField.test.3.tsx only
 
 There are some notable differences compared to the previous test:
 
-- The userEvent module is imported.
+- The `userEvent` module is imported.
 - A `user` is created with the `userEvent.setup()` function.
 - The callback function argument of `it` is prefaced with `async`.
 - We need to `await` the `type` method to let it complete.

--- a/src/react-native/09-react-context/react-context.md
+++ b/src/react-native/09-react-context/react-context.md
@@ -43,7 +43,7 @@ First we create a definition of what information will be stored, then we get the
 
 #### Provider
 
-The Provider is how we actually tell React to store our data. We can render the provider anywhere in our tree, and the data will be accessible anywhere inside. To keep things performant, we will usually want to memoize these values. (Don't worry if `useState` looks odd. We'll be covering this shortly.)
+The Provider is how we actually tell React to store our data. We can render the provider anywhere in our tree, and the data will be accessible anywhere inside. To keep things performant, we will usually want to memoize these values. (Don’t worry if `useState` looks odd. We'll be covering this shortly.)
 
 @sourceref ./context-basic.tsx
 @highlight 33-42, only
@@ -67,7 +67,7 @@ To help keep things clean in the future, it is best practice to keep this Contex
 
 #### Provider
 
-We can create a custom `AuthProvider` that hides all the complicated logic from other components. Sometimes a custom provider will even take props (such as an access token), though this one doesn't require any.
+We can create a custom `AuthProvider` that hides all the complicated logic from other components. Sometimes a custom provider will even take props (such as an access token), though this one doesn’t require any.
 
 @sourceref ./context-full.tsx
 @highlight 22-45, only

--- a/src/react-native/11-navigation/navigation.md
+++ b/src/react-native/11-navigation/navigation.md
@@ -174,7 +174,7 @@ React Native does not have a built-in global history stack similar to a web brow
 
 The React Navigation library provides both a stack navigator as well as a native stack navigator. The native stack navigator uses the native APIs provided by the platform, `UINavigationController` on iOS and `Fragment` on Android. Because it is using the native APIs, it provides native performance and exposes native-specific features. Although the stack navigator is not as performant, it does provide several other benefits:
 
-- Flexibility and Customization: The JS navigator offers more flexibility in customization. You can tweak animations, transitions, and behaviors directly in JavaScript, which can be advantageous if you need highly customized navigation flows that aren't easily achieved with native components.
+- Flexibility and Customization: The JS navigator offers more flexibility in customization. You can tweak animations, transitions, and behaviors directly in JavaScript, which can be advantageous if you need highly customized navigation flows that aren’t easily achieved with native components.
 
 - Simpler Setup and Debugging: Since JS navigators are implemented entirely in JavaScript, you don’t have to deal with native code, making setup, maintenance, and debugging generally simpler. This can speed up development, especially if your team specializes in JavaScript and does not have as much experience with native mobile development.
 

--- a/src/react-native/12-navigation-params/navigation-params.md
+++ b/src/react-native/12-navigation-params/navigation-params.md
@@ -19,14 +19,14 @@ Now that we've successfully implemented React Navigation in our application, we 
 
 ### Navigation Parameters
 
-As mentioned in the previous section, since our React Native application isn't navigated through URLs, we aren't able to pass the parameters through a URL. Instead, we'll be using the Stack we've already made.
+As mentioned in the previous section, since our React Native application isn’t navigated through URLs, we aren’t able to pass the parameters through a URL. Instead, we'll be using the Stack we've already made.
 
 @sourceref ./StackRoute.tsx
 @highlight 4-23, 25
 
 Before we get into using `route` on each `Screen` of the `Navigator`, considering we're using TypeScript, we need to make an effort to make sure the properties for each component are properly typed. For this, we will create a type, `ShopStackParamList`.
 
-For each screen we will type the expected properties that will be passed along each route. The `Home` in this case doesn't expect any parameters to be passed to it, so we leave it undefined. The `UserProfile` and `Storefront` contain a few properties.
+For each screen we will type the expected properties that will be passed along each route. The `Home` in this case doesn’t expect any parameters to be passed to it, so we leave it undefined. The `UserProfile` and `Storefront` contain a few properties.
 
 Now, our `createStackNavigator` includes a type we've made `ShopStackParamList`. Because of this, now if we provide our screen components `Props` as route params, TypeScript will be able to able to identify what parameters are accessible from the components `route.params`.
 

--- a/src/react-native/15-using-asyncstorage/using-asyncstorage.md
+++ b/src/react-native/15-using-asyncstorage/using-asyncstorage.md
@@ -97,7 +97,7 @@ There are _many_ different types of caching strategies for network requests:
 
 - **Network with cache fallback:** The primary approach is to fetch data from the network, but if the network is unavailable or the request fails, data is loaded from the cache. This is useful for maintaining functionality when offline or in poor network conditions.
 
-- **Conditional cache strategy:** Using conditional requests with cache tags (like ETag) or timestamps, the app can minimize data transfer by asking the server if there are updates since the last fetch. If the data hasn't changed, the server returns a not-modified status, allowing the app to use cached data.
+- **Conditional cache strategy:** Using conditional requests with cache tags (like ETag) or timestamps, the app can minimize data transfer by asking the server if there are updates since the last fetch. If the data hasn’t changed, the server returns a not-modified status, allowing the app to use cached data.
 
 - **Incremental cache update:** Suitable for data that can be partitioned or incremental updates (like paginated queries). Instead of refreshing the entire cache, only new or updated data chunks are fetched and cached.
 


### PR DESCRIPTION
- Add the rendered `EmailInputField` JSX to the content.
- Make the example code match our guidelines.
- Replace old DOM/element references with components/views.
- Replace mentions with `user-event` as a separate package with `userEvent` as the API provided by RNTL.
- Other minor edits.