### PR TITLE
Make the TOC display next to the sidebar at smaller widths

### DIFF
--- a/static/styles/styles.less
+++ b/static/styles/styles.less
@@ -76,6 +76,11 @@ header, footer {
   grid-template-areas: "sidebar" "toc" "main";
   grid-template-columns: minmax(0, 1fr);
 
+  @media (min-width: 500px) {
+    grid-template-areas: "sidebar toc" "main main";
+    grid-template-columns: min-content 1fr;
+  }
+
   @media (min-width: 1024px) {
     grid-template-areas: "sidebar main toc";
     grid-template-columns: max-content minmax(0, 1fr) fit-content(25%);


### PR DESCRIPTION
Previously, the TOC would display underneath the sidebar all the way until when all three columns were able to be next to each other.

Now, between the one-column and three-column layouts, there’s a new two-column layout that will show the TOC next to the sidebar.