### PR TITLE
fixed link on the first page

### DIFF
--- a/src/react-native/react-native.md
+++ b/src/react-native/react-native.md
@@ -59,4 +59,4 @@ Throughout this guide, we’ll be building out a feature-rich Place My Order app
 
 ## Next steps
 
-✏️ Head over to the [first lesson](learn-react-native/intro-to-react.html) to get a more thorough overview of React Native and the technologies it provides.
+✏️ Head over to the [first lesson](learn-react-native/intro-to-react-native.html) to get a more thorough overview of React Native and the technologies it provides.


### PR DESCRIPTION
- [x] Link to Jira Ticket: 
https://bitovi.atlassian.net/browse/FE-248
      
- [x] Short description of changes:
The link on the intro page that navigates to the first lesson was broken. It was missing a `-native` in the URL.
    
